### PR TITLE
Add product-level unit of measure

### DIFF
--- a/Homassy.API/Entities/Product/Product.cs
+++ b/Homassy.API/Entities/Product/Product.cs
@@ -15,6 +15,10 @@ namespace Homassy.API.Entities.Product
 
 
         public ProductCategory? Category { get; set; }
+
+        [EnumDataType(typeof(Unit))]
+        public Unit Unit { get; set; } = Unit.Piece;
+
         [ValidBarcode]
         [StringLength(14, MinimumLength = 6)]
         public string? Barcode { get; set; }

--- a/Homassy.API/Functions/AutomationFunctions.cs
+++ b/Homassy.API/Functions/AutomationFunctions.cs
@@ -153,19 +153,18 @@ namespace Homassy.API.Functions
         }
 
         /// <summary>
-        /// Validates that auto-consume rules have quantity and unit set,
-        /// and AddToShoppingList / LowStockAddToShoppingList rules have the required fields.
+        /// Validates that auto-consume rules have a quantity set, and
+        /// AddToShoppingList / LowStockAddToShoppingList rules have the required fields.
+        /// The unit is always inherited from the related product, so it is not validated here.
         /// </summary>
-        public static void ValidateActionType(AutomationActionType actionType, decimal? consumeQuantity, Unit? consumeUnit,
-            Guid? shoppingListPublicId = null, Guid? productPublicId = null, decimal? addQuantity = null, Unit? addUnit = null,
+        public static void ValidateActionType(AutomationActionType actionType, decimal? consumeQuantity,
+            Guid? shoppingListPublicId = null, Guid? productPublicId = null, decimal? addQuantity = null,
             decimal? thresholdQuantity = null)
         {
             if (actionType == AutomationActionType.AutoConsume)
             {
                 if (!consumeQuantity.HasValue || consumeQuantity.Value <= 0)
                     throw new AutomationInvalidScheduleException("AutoConsume action requires ConsumeQuantity > 0");
-                if (!consumeUnit.HasValue)
-                    throw new AutomationInvalidScheduleException("AutoConsume action requires ConsumeUnit");
             }
             else if (actionType == AutomationActionType.AddToShoppingList)
             {
@@ -175,8 +174,6 @@ namespace Homassy.API.Functions
                     throw new AutomationInvalidScheduleException("AddToShoppingList action requires ProductPublicId");
                 if (!addQuantity.HasValue || addQuantity.Value <= 0)
                     throw new AutomationInvalidScheduleException("AddToShoppingList action requires AddQuantity > 0");
-                if (!addUnit.HasValue)
-                    throw new AutomationInvalidScheduleException("AddToShoppingList action requires AddUnit");
             }
             else if (actionType == AutomationActionType.LowStockAddToShoppingList)
             {
@@ -188,8 +185,6 @@ namespace Homassy.API.Functions
                     throw new AutomationInvalidScheduleException("LowStockAddToShoppingList action requires ProductPublicId");
                 if (!addQuantity.HasValue || addQuantity.Value <= 0)
                     throw new AutomationInvalidScheduleException("LowStockAddToShoppingList action requires AddQuantity > 0");
-                if (!addUnit.HasValue)
-                    throw new AutomationInvalidScheduleException("LowStockAddToShoppingList action requires AddUnit");
             }
         }
 
@@ -283,8 +278,8 @@ namespace Homassy.API.Functions
             // Validate schedule (skip for low-stock — event-driven, not schedule-driven)
             if (request.ActionType != AutomationActionType.LowStockAddToShoppingList)
                 ValidateSchedule(request.ScheduleType, request.IntervalDays, request.ScheduledDaysOfWeek, request.ScheduledDayOfMonth);
-            ValidateActionType(request.ActionType, request.ConsumeQuantity, request.ConsumeUnit,
-                request.ShoppingListPublicId, request.ProductPublicId, request.AddQuantity, request.AddUnit,
+            ValidateActionType(request.ActionType, request.ConsumeQuantity,
+                request.ShoppingListPublicId, request.ProductPublicId, request.AddQuantity,
                 request.ThresholdQuantity);
 
             var productFunctions = new ProductFunctions();
@@ -336,6 +331,12 @@ namespace Homassy.API.Functions
             var userProfile = new UserFunctions().GetUserProfileByUserId(userId.Value);
             var userTimeZone = userProfile?.DefaultTimeZone ?? UserTimeZone.CentralEuropeStandardTime;
 
+            // The unit is always inherited from the related product (no longer supplied by the client).
+            var derivedUnit = productEntity?.Unit
+                ?? (inventoryItem != null ? productFunctions.GetProductById(inventoryItem.ProductId)?.Unit : null);
+            var isAddAction = request.ActionType == AutomationActionType.AddToShoppingList
+                || request.ActionType == AutomationActionType.LowStockAddToShoppingList;
+
             var automation = new ItemAutomation
             {
                 ProductInventoryItemId = inventoryItem?.Id,
@@ -351,9 +352,9 @@ namespace Homassy.API.Functions
                 ScheduledTime = request.ScheduledTime,
                 ActionType = request.ActionType,
                 ConsumeQuantity = request.ConsumeQuantity,
-                ConsumeUnit = request.ConsumeUnit,
+                ConsumeUnit = isAddAction ? null : derivedUnit,
                 AddQuantity = request.AddQuantity,
-                AddUnit = request.AddUnit,
+                AddUnit = isAddAction ? derivedUnit : null,
                 ThresholdQuantity = request.ThresholdQuantity,
                 IsEnabled = true
             };
@@ -427,9 +428,10 @@ namespace Homassy.API.Functions
             var scheduledDayOfMonth = request.ScheduledDayOfMonth ?? automation.ScheduledDayOfMonth;
             var actionType = request.ActionType ?? automation.ActionType;
             var consumeQuantity = request.ConsumeQuantity ?? automation.ConsumeQuantity;
-            var consumeUnit = request.ConsumeUnit ?? automation.ConsumeUnit;
+            // Units are inherited from the product and not editable via the request.
+            var consumeUnit = automation.ConsumeUnit;
             var addQuantity = request.AddQuantity ?? automation.AddQuantity;
-            var addUnit = request.AddUnit ?? automation.AddUnit;
+            var addUnit = automation.AddUnit;
             var thresholdQuantity = request.ThresholdQuantity ?? automation.ThresholdQuantity;
 
             // Validate after merge (skip schedule validation for low-stock — event-driven)
@@ -437,15 +439,15 @@ namespace Homassy.API.Functions
                 ValidateSchedule(scheduleType, intervalDays, scheduledDaysOfWeek, scheduledDayOfMonth);
 
             // Only validate action type fields when action-type-related properties are being changed
-            if (request.ActionType.HasValue || request.ConsumeQuantity.HasValue || request.ConsumeUnit.HasValue ||
-                request.AddQuantity.HasValue || request.AddUnit.HasValue ||
+            if (request.ActionType.HasValue || request.ConsumeQuantity.HasValue ||
+                request.AddQuantity.HasValue ||
                 request.ShoppingListPublicId.HasValue || request.ProductPublicId.HasValue ||
                 request.ThresholdQuantity.HasValue)
             {
                 // For update, use existing entity IDs if not provided in request
                 var shoppingListPublicId = request.ShoppingListPublicId ?? (automation.ShoppingListId.HasValue ? Guid.Empty : (Guid?)null);
                 var productPublicId = request.ProductPublicId ?? (automation.ProductId.HasValue ? Guid.Empty : (Guid?)null);
-                ValidateActionType(actionType, consumeQuantity, consumeUnit, shoppingListPublicId, productPublicId, addQuantity, addUnit, thresholdQuantity);
+                ValidateActionType(actionType, consumeQuantity, shoppingListPublicId, productPublicId, addQuantity, thresholdQuantity);
             }
 
             automation.ScheduleType = scheduleType;

--- a/Homassy.API/Functions/ProductFunctions.cs
+++ b/Homassy.API/Functions/ProductFunctions.cs
@@ -498,6 +498,7 @@ namespace Homassy.API.Functions
                     Name = p.Name,
                     Brand = p.Brand,
                     Category = p.Category,
+                    Unit = p.Unit,
                     Barcode = p.Barcode,
                     ProductPictureBase64 = p.ProductPictureBase64,
                     IsEatable = p.IsEatable,
@@ -527,6 +528,7 @@ namespace Homassy.API.Functions
                     Name = request.Name.Trim(),
                     Brand = request.Brand.Trim(),
                     Category = request.Category,
+                    Unit = request.Unit,
                     Barcode = request.Barcode?.Trim(),
                     IsEatable = request.IsEatable
                 };
@@ -587,6 +589,7 @@ namespace Homassy.API.Functions
                     Name = product.Name,
                     Brand = product.Brand,
                     Category = product.Category,
+                    Unit = product.Unit,
                     Barcode = product.Barcode,
                     ProductPictureBase64 = product.ProductPictureBase64,
                     IsEatable = product.IsEatable,
@@ -638,6 +641,12 @@ namespace Homassy.API.Functions
                 if (request.Category != null)
                 {
                     product.Category = request.Category;
+                    hasChanges = true;
+                }
+
+                if (request.Unit.HasValue)
+                {
+                    product.Unit = request.Unit.Value;
                     hasChanges = true;
                 }
 
@@ -699,6 +708,7 @@ namespace Homassy.API.Functions
                     Name = product.Name,
                     Brand = product.Brand,
                     Category = product.Category,
+                    Unit = product.Unit,
                     Barcode = product.Barcode,
                     ProductPictureBase64 = product.ProductPictureBase64,
                     IsEatable = product.IsEatable,
@@ -836,6 +846,7 @@ namespace Homassy.API.Functions
                     Name = product.Name,
                     Brand = product.Brand,
                     Category = product.Category,
+                    Unit = product.Unit,
                     Barcode = product.Barcode,
                     ProductPictureBase64 = product.ProductPictureBase64,
                     IsEatable = product.IsEatable,
@@ -928,6 +939,7 @@ namespace Homassy.API.Functions
                 Name = product.Name,
                 Brand = product.Brand,
                 Category = product.Category,
+                Unit = product.Unit,
                 Barcode = product.Barcode,
                 ProductPictureBase64 = product.ProductPictureBase64,
                 IsEatable = product.IsEatable,
@@ -1031,6 +1043,7 @@ namespace Homassy.API.Functions
                     Name = product.Name,
                     Brand = product.Brand,
                     Category = product.Category,
+                    Unit = product.Unit,
                     Barcode = product.Barcode,
                     ProductPictureBase64 = product.ProductPictureBase64,
                     IsEatable = product.IsEatable,
@@ -1149,7 +1162,7 @@ namespace Homassy.API.Functions
                     FamilyId = request.IsSharedWithFamily && familyId.HasValue ? familyId : null,
                     StorageLocationId = storageLocationId,
                     CurrentQuantity = request.Quantity,
-                    Unit = request.Unit,
+                    Unit = product.Unit,
                     ExpirationAt = request.ExpirationAt
                 };
 
@@ -1269,7 +1282,7 @@ namespace Homassy.API.Functions
                     UserId = request.IsSharedWithFamily && familyId.HasValue ? null : userId.Value,
                     FamilyId = request.IsSharedWithFamily && familyId.HasValue ? familyId : null,
                     CurrentQuantity = request.Quantity,
-                    Unit = request.Unit
+                    Unit = product.Unit
                 };
 
                 context.ProductInventoryItems.Add(inventoryItem);
@@ -1368,12 +1381,6 @@ namespace Homassy.API.Functions
                 if (request.Quantity.HasValue)
                 {
                     trackedItem.CurrentQuantity = request.Quantity.Value;
-                    hasChanges = true;
-                }
-
-                if (request.Unit.HasValue)
-                {
-                    trackedItem.Unit = request.Unit.Value;
                     hasChanges = true;
                 }
 
@@ -1813,7 +1820,7 @@ namespace Homassy.API.Functions
                         FamilyId = request.IsSharedWithFamily && familyId.HasValue ? familyId : null,
                         StorageLocationId = storageLocationId,
                         CurrentQuantity = item.Quantity,
-                        Unit = item.Unit
+                        Unit = product.Unit
                     };
 
                     context.ProductInventoryItems.Add(inventoryItem);
@@ -2483,6 +2490,7 @@ namespace Homassy.API.Functions
                         Name = productRequest.Name.Trim(),
                         Brand = productRequest.Brand.Trim(),
                         Category = productRequest.Category,
+                        Unit = productRequest.Unit,
                         Barcode = productRequest.Barcode?.Trim(),
                         IsEatable = productRequest.IsEatable
                     };
@@ -2512,6 +2520,7 @@ namespace Homassy.API.Functions
                         Name = product.Name,
                         Brand = product.Brand,
                         Category = product.Category,
+                    Unit = product.Unit,
                         Barcode = product.Barcode,
                         ProductPictureBase64 = product.ProductPictureBase64,
                         IsEatable = product.IsEatable,
@@ -2551,6 +2560,7 @@ namespace Homassy.API.Functions
                 Name = product.Name,
                 Brand = product.Brand,
                 Category = product.Category,
+                Unit = product.Unit,
                 Barcode = product.Barcode,
                 ProductPictureBase64 = product.ProductPictureBase64,
                 IsEatable = product.IsEatable,

--- a/Homassy.API/Functions/ShoppingListFunctions.cs
+++ b/Homassy.API/Functions/ShoppingListFunctions.cs
@@ -735,6 +735,10 @@ namespace Homassy.API.Functions
             int? productId = null;
             int? shoppingLocationId = null;
 
+            // For product-linked items the unit is inherited from the product; for standalone
+            // (custom) items it comes from the request (defaulting to Piece).
+            var itemUnit = request.Unit ?? Homassy.API.Enums.Unit.Piece;
+
             if (request.ProductPublicId.HasValue)
             {
                 var product = productFunctions.GetProductByPublicId(request.ProductPublicId.Value);
@@ -743,6 +747,7 @@ namespace Homassy.API.Functions
                     throw new ProductNotFoundException("Product not found");
                 }
                 productId = product.Id;
+                itemUnit = product.Unit;
             }
 
             if (request.ShoppingLocationPublicId.HasValue)
@@ -767,7 +772,7 @@ namespace Homassy.API.Functions
                     ShoppingLocationId = shoppingLocationId,
                     CustomName = request.CustomName?.Trim(),
                     Quantity = request.Quantity,
-                    Unit = request.Unit,
+                    Unit = itemUnit,
                     Note = request.Note?.Trim(),
                     DeadlineAt = request.DeadlineAt,
                     DueAt = request.DueAt
@@ -876,6 +881,8 @@ namespace Homassy.API.Functions
                         throw new ProductNotFoundException("Product not found");
                     }
                     trackedItem.ProductId = product.Id;
+                    // Product-linked items inherit the unit from the product.
+                    trackedItem.Unit = product.Unit;
                     hasChanges = true;
                 }
 
@@ -904,7 +911,8 @@ namespace Homassy.API.Functions
                     hasChanges = true;
                 }
 
-                if (request.Unit.HasValue)
+                // Unit is only editable for standalone/custom items (no linked product).
+                if (request.Unit.HasValue && !trackedItem.ProductId.HasValue)
                 {
                     trackedItem.Unit = request.Unit.Value;
                     hasChanges = true;
@@ -1524,6 +1532,10 @@ namespace Homassy.API.Functions
                     int? productId = null;
                     int? shoppingLocationId = null;
 
+                    // Product-linked items inherit the unit from the product; standalone
+                    // (custom) items use the unit from the request (defaulting to Piece).
+                    var itemUnit = item.Unit ?? Homassy.API.Enums.Unit.Piece;
+
                     if (item.ProductPublicId.HasValue)
                     {
                         var product = productFunctions.GetProductByPublicId(item.ProductPublicId.Value);
@@ -1532,6 +1544,7 @@ namespace Homassy.API.Functions
                             throw new ProductNotFoundException($"Product not found: {item.ProductPublicId}");
                         }
                         productId = product.Id;
+                        itemUnit = product.Unit;
                     }
 
                     if (item.ShoppingLocationPublicId.HasValue)
@@ -1551,7 +1564,7 @@ namespace Homassy.API.Functions
                         ShoppingLocationId = shoppingLocationId,
                         CustomName = item.CustomName?.Trim(),
                         Quantity = item.Quantity,
-                        Unit = item.Unit,
+                        Unit = itemUnit,
                         Note = item.Note?.Trim(),
                         DeadlineAt = item.DeadlineAt,
                         DueAt = item.DueAt

--- a/Homassy.API/Homassy.API.json
+++ b/Homassy.API/Homassy.API.json
@@ -11,7 +11,7 @@
       "name": "MIT License",
       "url": "https://github.com/Xentinus/Homassy/blob/master/LICENSE"
     },
-    "version": "26.0409.1524-dev"
+    "version": "26.0621.1708-dev"
   },
   "paths": {
     "/api/v1/Auth/me": {
@@ -7996,16 +7996,6 @@
             ],
             "format": "double"
           },
-          "consumeUnit": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/Unit"
-              }
-            ]
-          },
           "addQuantity": {
             "minimum": 0.001,
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
@@ -8015,16 +8005,6 @@
               "string"
             ],
             "format": "double"
-          },
-          "addUnit": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/Unit"
-              }
-            ]
           },
           "thresholdQuantity": {
             "minimum": 0.001,
@@ -8098,9 +8078,6 @@
               "string"
             ],
             "format": "double"
-          },
-          "unit": {
-            "$ref": "#/components/schemas/Unit"
           },
           "expirationAt": {
             "type": [
@@ -8213,7 +8190,8 @@
       "CreateProductRequest": {
         "required": [
           "name",
-          "brand"
+          "brand",
+          "unit"
         ],
         "type": "object",
         "properties": {
@@ -8236,6 +8214,9 @@
                 "$ref": "#/components/schemas/ProductCategory"
               }
             ]
+          },
+          "unit": {
+            "$ref": "#/components/schemas/Unit"
           },
           "barcode": {
             "maxLength": 14,
@@ -8296,8 +8277,7 @@
       },
       "CreateShoppingListItemEntry": {
         "required": [
-          "quantity",
-          "unit"
+          "quantity"
         ],
         "type": "object",
         "properties": {
@@ -8333,7 +8313,14 @@
             "format": "double"
           },
           "unit": {
-            "$ref": "#/components/schemas/Unit"
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Unit"
+              }
+            ]
           },
           "note": {
             "maxLength": 255,
@@ -8362,8 +8349,7 @@
       "CreateShoppingListItemRequest": {
         "required": [
           "shoppingListPublicId",
-          "quantity",
-          "unit"
+          "quantity"
         ],
         "type": "object",
         "properties": {
@@ -8403,7 +8389,14 @@
             "format": "double"
           },
           "unit": {
-            "$ref": "#/components/schemas/Unit"
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Unit"
+              }
+            ]
           },
           "note": {
             "maxLength": 255,
@@ -8603,6 +8596,9 @@
                 "$ref": "#/components/schemas/ProductCategory"
               }
             ]
+          },
+          "unit": {
+            "$ref": "#/components/schemas/Unit"
           },
           "barcode": {
             "type": [
@@ -9718,6 +9714,9 @@
               }
             ]
           },
+          "unit": {
+            "$ref": "#/components/schemas/Unit"
+          },
           "barcode": {
             "type": [
               "null",
@@ -9837,9 +9836,6 @@
             ],
             "format": "double"
           },
-          "unit": {
-            "$ref": "#/components/schemas/Unit"
-          },
           "isSharedWithFamily": {
             "type": "boolean"
           }
@@ -9864,9 +9860,6 @@
               "string"
             ],
             "format": "double"
-          },
-          "unit": {
-            "$ref": "#/components/schemas/Unit"
           }
         }
       },
@@ -10455,16 +10448,6 @@
             ],
             "format": "double"
           },
-          "consumeUnit": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/Unit"
-              }
-            ]
-          },
           "addQuantity": {
             "minimum": 0.001,
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
@@ -10474,16 +10457,6 @@
               "string"
             ],
             "format": "double"
-          },
-          "addUnit": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/Unit"
-              }
-            ]
           },
           "shoppingListPublicId": {
             "type": [
@@ -10557,16 +10530,6 @@
               "string"
             ],
             "format": "double"
-          },
-          "unit": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/Unit"
-              }
-            ]
           },
           "expirationAt": {
             "type": [
@@ -10678,6 +10641,16 @@
               },
               {
                 "$ref": "#/components/schemas/ProductCategory"
+              }
+            ]
+          },
+          "unit": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Unit"
               }
             ]
           },

--- a/Homassy.API/Migrations/20260621143813_AddUnitToProduct.Designer.cs
+++ b/Homassy.API/Migrations/20260621143813_AddUnitToProduct.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Homassy.API.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Homassy.API.Migrations
 {
     [DbContext(typeof(HomassyDbContext))]
-    partial class HomassyDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260621143813_AddUnitToProduct")]
+    partial class AddUnitToProduct
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Homassy.API/Migrations/20260621143813_AddUnitToProduct.cs
+++ b/Homassy.API/Migrations/20260621143813_AddUnitToProduct.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Homassy.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUnitToProduct : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Unit",
+                table: "Products",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Unit",
+                table: "Products");
+        }
+    }
+}

--- a/Homassy.API/Models/Automation/CreateAutomationRequest.cs
+++ b/Homassy.API/Models/Automation/CreateAutomationRequest.cs
@@ -34,14 +34,8 @@ namespace Homassy.API.Models.Automation
         [Range(0.001, double.MaxValue, ErrorMessage = "Consume quantity must be greater than 0")]
         public decimal? ConsumeQuantity { get; set; }
 
-        [EnumDataType(typeof(Unit))]
-        public Unit? ConsumeUnit { get; set; }
-
         [Range(0.001, double.MaxValue, ErrorMessage = "Add quantity must be greater than 0")]
         public decimal? AddQuantity { get; set; }
-
-        [EnumDataType(typeof(Unit))]
-        public Unit? AddUnit { get; set; }
 
         [Range(0.001, double.MaxValue, ErrorMessage = "Threshold quantity must be greater than 0")]
         public decimal? ThresholdQuantity { get; set; }

--- a/Homassy.API/Models/Automation/UpdateAutomationRequest.cs
+++ b/Homassy.API/Models/Automation/UpdateAutomationRequest.cs
@@ -25,14 +25,8 @@ namespace Homassy.API.Models.Automation
         [Range(0.001, double.MaxValue, ErrorMessage = "Consume quantity must be greater than 0")]
         public decimal? ConsumeQuantity { get; set; }
 
-        [EnumDataType(typeof(Unit))]
-        public Unit? ConsumeUnit { get; set; }
-
         [Range(0.001, double.MaxValue, ErrorMessage = "Add quantity must be greater than 0")]
         public decimal? AddQuantity { get; set; }
-
-        [EnumDataType(typeof(Unit))]
-        public Unit? AddUnit { get; set; }
 
         public Guid? ShoppingListPublicId { get; set; }
 

--- a/Homassy.API/Models/Product/CreateInventoryItemRequest.cs
+++ b/Homassy.API/Models/Product/CreateInventoryItemRequest.cs
@@ -16,9 +16,6 @@ namespace Homassy.API.Models.Product
         [Range(0.001, double.MaxValue, ErrorMessage = "Quantity must be greater than 0")]
         public required decimal Quantity { get; set; }
 
-        [EnumDataType(typeof(Unit))]
-        public Unit Unit { get; set; } = Unit.Piece;
-
         public DateTime? ExpirationAt { get; set; }
 
         public int? Price { get; set; }

--- a/Homassy.API/Models/Product/CreateProductRequest.cs
+++ b/Homassy.API/Models/Product/CreateProductRequest.cs
@@ -18,6 +18,10 @@ namespace Homassy.API.Models.Product
 
         public ProductCategory? Category { get; set; }
 
+        [Required]
+        [EnumDataType(typeof(Unit))]
+        public required Unit Unit { get; set; }
+
         [ValidBarcode]
         [StringLength(14, MinimumLength = 6)]
         public string? Barcode { get; set; }

--- a/Homassy.API/Models/Product/ProductInfo.cs
+++ b/Homassy.API/Models/Product/ProductInfo.cs
@@ -8,6 +8,7 @@ namespace Homassy.API.Models.Product
         public string Name { get; set; } = string.Empty;
         public string Brand { get; set; } = string.Empty;
         public ProductCategory? Category { get; set; }
+        public Unit Unit { get; set; }
         public string? Barcode { get; set; }
         public string? ProductPictureBase64 { get; set; }
         public bool IsEatable { get; set; }

--- a/Homassy.API/Models/Product/QuickAddInventoryItemRequest.cs
+++ b/Homassy.API/Models/Product/QuickAddInventoryItemRequest.cs
@@ -12,9 +12,6 @@ namespace Homassy.API.Models.Product
         [Range(0.001, double.MaxValue, ErrorMessage = "Quantity must be greater than 0")]
         public required decimal Quantity { get; set; }
 
-        [EnumDataType(typeof(Unit))]
-        public Unit Unit { get; set; } = Unit.Piece;
-
         public bool IsSharedWithFamily { get; set; } = false;
     }
 }

--- a/Homassy.API/Models/Product/QuickAddMultipleInventoryItemEntry.cs
+++ b/Homassy.API/Models/Product/QuickAddMultipleInventoryItemEntry.cs
@@ -11,7 +11,4 @@ public class QuickAddMultipleInventoryItemEntry
     [Required]
     [Range(0.001, double.MaxValue, ErrorMessage = "Quantity must be greater than 0")]
     public required decimal Quantity { get; set; }
-
-    [EnumDataType(typeof(Unit))]
-    public Unit Unit { get; set; } = Unit.Piece;
 }

--- a/Homassy.API/Models/Product/UpdateInventoryItemRequest.cs
+++ b/Homassy.API/Models/Product/UpdateInventoryItemRequest.cs
@@ -10,9 +10,6 @@ namespace Homassy.API.Models.Product
         [Range(0, double.MaxValue, ErrorMessage = "Quantity cannot be negative")]
         public decimal? Quantity { get; set; }
 
-        [EnumDataType(typeof(Unit))]
-        public Unit? Unit { get; set; }
-
         public DateTime? ExpirationAt { get; set; }
 
         public bool? IsSharedWithFamily { get; set; }

--- a/Homassy.API/Models/Product/UpdateProductRequest.cs
+++ b/Homassy.API/Models/Product/UpdateProductRequest.cs
@@ -16,6 +16,9 @@ namespace Homassy.API.Models.Product
 
         public ProductCategory? Category { get; set; }
 
+        [EnumDataType(typeof(Unit))]
+        public Unit? Unit { get; set; }
+
         [ValidBarcode]
         [StringLength(14, MinimumLength = 6)]
         public string? Barcode { get; set; }

--- a/Homassy.API/Models/ShoppingList/CreateShoppingListItemEntry.cs
+++ b/Homassy.API/Models/ShoppingList/CreateShoppingListItemEntry.cs
@@ -18,9 +18,10 @@ namespace Homassy.API.Models.ShoppingList
         [Range(0.001, double.MaxValue, ErrorMessage = "Quantity must be greater than 0")]
         public required decimal Quantity { get; set; } = 1.0m;
 
-        [Required]
+        // Only used for standalone/custom items (no ProductPublicId). For product-linked
+        // items the unit is inherited from the product and this value is ignored.
         [EnumDataType(typeof(Unit))]
-        public required Unit Unit { get; set; } = Unit.Piece;
+        public Unit? Unit { get; set; }
 
         [StringLength(255)]
         [SanitizedString]

--- a/Homassy.API/Models/ShoppingList/CreateShoppingListItemRequest.cs
+++ b/Homassy.API/Models/ShoppingList/CreateShoppingListItemRequest.cs
@@ -21,9 +21,10 @@ namespace Homassy.API.Models.ShoppingList
         [Range(0.001, double.MaxValue, ErrorMessage = "Quantity must be greater than 0")]
         public required decimal Quantity { get; set; } = 1.0m;
 
-        [Required]
+        // Only used for standalone/custom items (no ProductPublicId). For product-linked
+        // items the unit is inherited from the product and this value is ignored.
         [EnumDataType(typeof(Unit))]
-        public required Unit Unit { get; set; } = Unit.Piece;
+        public Unit? Unit { get; set; }
 
         [StringLength(255)]
         [SanitizedString]

--- a/Homassy.Tests/Integration/ProductControllerTests.cs
+++ b/Homassy.Tests/Integration/ProductControllerTests.cs
@@ -36,7 +36,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
     [Fact]
     public async Task CreateProduct_WithoutToken_ReturnsUnauthorized()
     {
-        var request = new CreateProductRequest { Name = "Test Product", Brand = "Test Brand" };
+        var request = new CreateProductRequest { Unit = ProductUnit.Piece, Name = "Test Product", Brand = "Test Brand" };
         var response = await _client.PostAsJsonAsync("/api/v1.0/product", request);
         _output.WriteLine($"Status: {response.StatusCode}");
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -145,6 +145,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
 
             var request = new CreateProductRequest
             {
+                Unit = ProductUnit.Piece,
                 Name = "A", // Too short, minimum is 2
                 Brand = "Test Brand"
             };
@@ -177,6 +178,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
 
             var request = new CreateProductRequest
             {
+                Unit = ProductUnit.Piece,
                 Name = "Test Product",
                 Brand = "Test Brand",
                 Barcode = "ABC123" // Invalid, must be digits only
@@ -308,6 +310,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
             _output.WriteLine("\n=== Step 2: Create Product ===");
             var createRequest = new CreateProductRequest
             {
+                Unit = ProductUnit.Piece,
                 Name = "Test Milk",
                 Brand = "Test Dairy",
                 Category = ProductCategory.Milk,
@@ -481,7 +484,6 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
                 {
                     ProductPublicId = Guid.NewGuid(),
                     Quantity = 1,
-                    Unit = ProductUnit.Piece
                 }
             ]
         };
@@ -539,7 +541,6 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
                     {
                         ProductPublicId = Guid.NewGuid(), // Non-existent product
                         Quantity = 1,
-                        Unit = ProductUnit.Piece
                     }
                 ]
             };
@@ -572,7 +573,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
             _authHelper.SetAuthToken(auth.AccessToken);
 
             // Create a product first
-            var productRequest = new CreateProductRequest { Name = "Test Product", Brand = "Test Brand" };
+            var productRequest = new CreateProductRequest { Unit = ProductUnit.Piece, Name = "Test Product", Brand = "Test Brand" };
             var productResponse = await _client.PostAsJsonAsync("/api/v1.0/product", productRequest);
             var productContent = await productResponse.Content.ReadFromJsonAsync<ApiResponse<ProductInfo>>();
             productId = productContent?.Data?.PublicId;
@@ -585,7 +586,6 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
                     {
                         ProductPublicId = productId!.Value,
                         Quantity = 1,
-                        Unit = ProductUnit.Piece
                     }
                 ],
                 StorageLocationPublicId = Guid.NewGuid() // Non-existent storage location
@@ -628,7 +628,6 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
                     {
                         ProductPublicId = Guid.NewGuid(),
                         Quantity = 0, // Invalid - must be > 0
-                        Unit = ProductUnit.Piece
                     }
                 ]
             };
@@ -662,12 +661,12 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
             _authHelper.SetAuthToken(auth.AccessToken);
 
             // Create products first
-            var product1Request = new CreateProductRequest { Name = "Test Product 1", Brand = "Test Brand" };
+            var product1Request = new CreateProductRequest { Unit = ProductUnit.Piece, Name = "Test Product 1", Brand = "Test Brand" };
             var product1Response = await _client.PostAsJsonAsync("/api/v1.0/product", product1Request);
             var product1Content = await product1Response.Content.ReadFromJsonAsync<ApiResponse<ProductInfo>>();
             productId1 = product1Content?.Data?.PublicId;
 
-            var product2Request = new CreateProductRequest { Name = "Test Product 2", Brand = "Test Brand" };
+            var product2Request = new CreateProductRequest { Unit = ProductUnit.Piece, Name = "Test Product 2", Brand = "Test Brand" };
             var product2Response = await _client.PostAsJsonAsync("/api/v1.0/product", product2Request);
             var product2Content = await product2Response.Content.ReadFromJsonAsync<ApiResponse<ProductInfo>>();
             productId2 = product2Content?.Data?.PublicId;
@@ -682,13 +681,11 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
                     {
                         ProductPublicId = productId1!.Value,
                         Quantity = 5,
-                        Unit = ProductUnit.Piece
                     },
                     new QuickAddMultipleInventoryItemEntry
                     {
                         ProductPublicId = productId2!.Value,
                         Quantity = 2.5m,
-                        Unit = ProductUnit.Kilogram
                     }
                 ],
                 IsSharedWithFamily = false
@@ -861,7 +858,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
 
             // Step 1: Create a product
             _output.WriteLine("=== Step 1: Create Product ===");
-            var productRequest = new CreateProductRequest { Name = "Test Product", Brand = "Test Brand" };
+            var productRequest = new CreateProductRequest { Unit = ProductUnit.Piece, Name = "Test Product", Brand = "Test Brand" };
             var productResponse = await _client.PostAsJsonAsync("/api/v1.0/product", productRequest);
             var productContent = await productResponse.Content.ReadFromJsonAsync<ApiResponse<ProductInfo>>();
             productId = productContent?.Data?.PublicId;
@@ -873,7 +870,6 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
             {
                 ProductPublicId = productId!.Value,
                 Quantity = 5,
-                Unit = ProductUnit.Piece
             };
             var inventoryResponse = await _client.PostAsJsonAsync("/api/v1.0/product/inventory/quick", inventoryRequest);
             var inventoryContent = await inventoryResponse.Content.ReadFromJsonAsync<ApiResponse<InventoryItemInfo>>();
@@ -1023,7 +1019,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
             testEmail = email;
             _authHelper.SetAuthToken(auth.AccessToken);
 
-            var productRequest = new CreateProductRequest { Name = "Test Product", Brand = "Brand" };
+            var productRequest = new CreateProductRequest { Unit = ProductUnit.Piece, Name = "Test Product", Brand = "Brand" };
             var productResponse = await _client.PostAsJsonAsync("/api/v1.0/product", productRequest);
             var productContent = await productResponse.Content.ReadFromJsonAsync<ApiResponse<ProductInfo>>();
             productId = productContent?.Data?.PublicId;
@@ -1032,8 +1028,8 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
             {
                 Items =
                 [
-                    new QuickAddMultipleInventoryItemEntry { ProductPublicId = productId!.Value, Quantity = 1, Unit = ProductUnit.Piece },
-                    new QuickAddMultipleInventoryItemEntry { ProductPublicId = productId!.Value, Quantity = 2, Unit = ProductUnit.Piece }
+                    new QuickAddMultipleInventoryItemEntry { ProductPublicId = productId!.Value, Quantity = 1 },
+                    new QuickAddMultipleInventoryItemEntry { ProductPublicId = productId!.Value, Quantity = 2 }
                 ]
             };
             var addResponse = await _client.PostAsJsonAsync("/api/v1.0/product/inventory/quick/multiple", addRequest);
@@ -1112,7 +1108,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
             testEmail = email;
             _authHelper.SetAuthToken(auth.AccessToken);
 
-            var productRequest = new CreateProductRequest { Name = "Test Product", Brand = "Brand" };
+            var productRequest = new CreateProductRequest { Unit = ProductUnit.Piece, Name = "Test Product", Brand = "Brand" };
             var productResponse = await _client.PostAsJsonAsync("/api/v1.0/product", productRequest);
             var productContent = await productResponse.Content.ReadFromJsonAsync<ApiResponse<ProductInfo>>();
             productId = productContent?.Data?.PublicId;
@@ -1121,8 +1117,8 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
             {
                 Items =
                 [
-                    new QuickAddMultipleInventoryItemEntry { ProductPublicId = productId!.Value, Quantity = 10, Unit = ProductUnit.Piece },
-                    new QuickAddMultipleInventoryItemEntry { ProductPublicId = productId!.Value, Quantity = 5, Unit = ProductUnit.Piece }
+                    new QuickAddMultipleInventoryItemEntry { ProductPublicId = productId!.Value, Quantity = 10 },
+                    new QuickAddMultipleInventoryItemEntry { ProductPublicId = productId!.Value, Quantity = 5 }
                 ]
             };
             var addResponse = await _client.PostAsJsonAsync("/api/v1.0/product/inventory/quick/multiple", addRequest);
@@ -1169,7 +1165,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
     {
         var request = new CreateMultipleProductsRequest
         {
-            Products = [new CreateProductRequest { Name = "Test", Brand = "Brand" }]
+            Products = [new CreateProductRequest { Unit = ProductUnit.Piece, Name = "Test", Brand = "Brand" }]
         };
         var response = await _client.PostAsJsonAsync("/api/v1.0/product/multiple", request);
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -1214,9 +1210,9 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
             {
                 Products =
                 [
-                    new CreateProductRequest { Name = "Product 1", Brand = "Brand A", Category = ProductCategory.Grain },
-                    new CreateProductRequest { Name = "Product 2", Brand = "Brand B", IsEatable = false },
-                    new CreateProductRequest { Name = "Product 3", Brand = "Brand C", IsFavorite = true }
+                    new CreateProductRequest { Unit = ProductUnit.Piece, Name = "Product 1", Brand = "Brand A", Category = ProductCategory.Grain },
+                    new CreateProductRequest { Unit = ProductUnit.Piece, Name = "Product 2", Brand = "Brand B", IsEatable = false },
+                    new CreateProductRequest { Unit = ProductUnit.Piece, Name = "Product 3", Brand = "Brand C", IsFavorite = true }
                 ]
             };
 
@@ -1269,6 +1265,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
 
             var request = new CreateProductRequest
             {
+                Unit = ProductUnit.Piece,
                 Name = "Test Product",
                 Brand = "Test Brand",
                 Barcode = barcode
@@ -1313,6 +1310,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
 
             var request = new CreateProductRequest
             {
+                Unit = ProductUnit.Piece,
                 Name = "Test Product",
                 Brand = "Test Brand",
                 Barcode = barcode
@@ -1357,6 +1355,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
 
             var request = new CreateProductRequest
             {
+                Unit = ProductUnit.Piece,
                 Name = "Test Product",
                 Brand = "Test Brand",
                 Barcode = barcode
@@ -1400,6 +1399,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
 
             var request = new CreateProductRequest
             {
+                Unit = ProductUnit.Piece,
                 Name = "Test Product",
                 Brand = "Test Brand",
                 Barcode = barcode
@@ -1437,6 +1437,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
 
             var request = new CreateProductRequest
             {
+                Unit = ProductUnit.Piece,
                 Name = "Test Product",
                 Brand = "Test Brand",
                 Barcode = barcode
@@ -1473,6 +1474,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
 
             var request = new CreateProductRequest
             {
+                Unit = ProductUnit.Piece,
                 Name = "Test Product",
                 Brand = "Test Brand",
                 Barcode = barcode
@@ -1507,6 +1509,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
 
             var createRequest = new CreateProductRequest
             {
+                Unit = ProductUnit.Piece,
                 Name = "Test Product",
                 Brand = "Test Brand"
             };
@@ -1551,6 +1554,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
 
             var createRequest = new CreateProductRequest
             {
+                Unit = ProductUnit.Piece,
                 Name = "Test Product",
                 Brand = "Test Brand"
             };
@@ -1596,6 +1600,7 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
 
             var request = new CreateProductRequest
             {
+                Unit = ProductUnit.Piece,
                 Name = "Coca-Cola",
                 Brand = "Coca-Cola",
                 Barcode = "5449000000996"

--- a/Homassy.Tests/Integration/ShoppingListControllerTests.cs
+++ b/Homassy.Tests/Integration/ShoppingListControllerTests.cs
@@ -667,7 +667,7 @@ public class ShoppingListControllerTests : IClassFixture<HomassyWebApplicationFa
             testEmail = email;
             _authHelper.SetAuthToken(auth.AccessToken);
 
-            var productRequest = new CreateProductRequest { Name = "Test Product", Brand = "Test Brand" };
+            var productRequest = new CreateProductRequest { Unit = ProductUnit.Piece, Name = "Test Product", Brand = "Test Brand" };
             var productResponse = await _client.PostAsJsonAsync("/api/v1.0/product", productRequest);
             var productContent = await productResponse.Content.ReadFromJsonAsync<ApiResponse<ProductInfo>>();
             productId = productContent?.Data?.PublicId;
@@ -735,6 +735,7 @@ public class ShoppingListControllerTests : IClassFixture<HomassyWebApplicationFa
             _output.WriteLine("=== Step 1: Create Product ===");
             var productRequest = new CreateProductRequest
             {
+                Unit = ProductUnit.Piece,
                 Name = "Organic Milk",
                 Brand = "Test Dairy",
                 IsEatable = true
@@ -819,7 +820,7 @@ public class ShoppingListControllerTests : IClassFixture<HomassyWebApplicationFa
             testEmail = email;
             _authHelper.SetAuthToken(auth.AccessToken);
 
-            var productRequest = new CreateProductRequest { Name = "Test Product", Brand = "Test Brand" };
+            var productRequest = new CreateProductRequest { Unit = ProductUnit.Piece, Name = "Test Product", Brand = "Test Brand" };
             var productResponse = await _client.PostAsJsonAsync("/api/v1.0/product", productRequest);
             var productContent = await productResponse.Content.ReadFromJsonAsync<ApiResponse<ProductInfo>>();
             productId = productContent?.Data?.PublicId;
@@ -1147,12 +1148,12 @@ public class ShoppingListControllerTests : IClassFixture<HomassyWebApplicationFa
             testEmail = email;
             _authHelper.SetAuthToken(auth.AccessToken);
 
-            var product1Request = new CreateProductRequest { Name = "Product 1", Brand = "Brand" };
+            var product1Request = new CreateProductRequest { Unit = ProductUnit.Piece, Name = "Product 1", Brand = "Brand" };
             var product1Response = await _client.PostAsJsonAsync("/api/v1.0/product", product1Request);
             var product1Content = await product1Response.Content.ReadFromJsonAsync<ApiResponse<ProductInfo>>();
             productId1 = product1Content?.Data?.PublicId;
 
-            var product2Request = new CreateProductRequest { Name = "Product 2", Brand = "Brand" };
+            var product2Request = new CreateProductRequest { Unit = ProductUnit.Piece, Name = "Product 2", Brand = "Brand" };
             var product2Response = await _client.PostAsJsonAsync("/api/v1.0/product", product2Request);
             var product2Content = await product2Response.Content.ReadFromJsonAsync<ApiResponse<ProductInfo>>();
             productId2 = product2Content?.Data?.PublicId;

--- a/Homassy.Tests/Unit/AutomationFunctionsTests.cs
+++ b/Homassy.Tests/Unit/AutomationFunctionsTests.cs
@@ -1,7 +1,6 @@
 ﻿using Homassy.API.Enums;
 using Homassy.API.Exceptions;
 using Homassy.API.Functions;
-using ApiUnit = Homassy.API.Enums.Unit;
 
 namespace Homassy.Tests.Unit;
 
@@ -418,49 +417,42 @@ public class AutomationFunctionsTests
     [Fact]
     public void ValidateActionType_AutoConsume_Valid()
     {
-        AutomationFunctions.ValidateActionType(AutomationActionType.AutoConsume, 1.5m, ApiUnit.Piece);
+        AutomationFunctions.ValidateActionType(AutomationActionType.AutoConsume, 1.5m);
     }
 
     [Fact]
     public void ValidateActionType_AutoConsume_NoQuantity_Throws()
     {
         Assert.Throws<AutomationInvalidScheduleException>(() =>
-            AutomationFunctions.ValidateActionType(AutomationActionType.AutoConsume, null, ApiUnit.Piece));
+            AutomationFunctions.ValidateActionType(AutomationActionType.AutoConsume, null));
     }
 
     [Fact]
     public void ValidateActionType_AutoConsume_ZeroQuantity_Throws()
     {
         Assert.Throws<AutomationInvalidScheduleException>(() =>
-            AutomationFunctions.ValidateActionType(AutomationActionType.AutoConsume, 0, ApiUnit.Piece));
+            AutomationFunctions.ValidateActionType(AutomationActionType.AutoConsume, 0));
     }
 
     [Fact]
     public void ValidateActionType_AutoConsume_NegativeQuantity_Throws()
     {
         Assert.Throws<AutomationInvalidScheduleException>(() =>
-            AutomationFunctions.ValidateActionType(AutomationActionType.AutoConsume, -1m, ApiUnit.Piece));
-    }
-
-    [Fact]
-    public void ValidateActionType_AutoConsume_NoUnit_Throws()
-    {
-        Assert.Throws<AutomationInvalidScheduleException>(() =>
-            AutomationFunctions.ValidateActionType(AutomationActionType.AutoConsume, 1.5m, null));
+            AutomationFunctions.ValidateActionType(AutomationActionType.AutoConsume, -1m));
     }
 
     [Fact]
     public void ValidateActionType_NotifyOnly_NoQuantity_DoesNotThrow()
     {
         // NotifyOnly does not require quantity or unit
-        AutomationFunctions.ValidateActionType(AutomationActionType.NotifyOnly, null, null);
+        AutomationFunctions.ValidateActionType(AutomationActionType.NotifyOnly, null);
     }
 
     [Fact]
     public void ValidateActionType_NotifyOnly_WithQuantity_DoesNotThrow()
     {
         // NotifyOnly can optionally have quantity (ignored)
-        AutomationFunctions.ValidateActionType(AutomationActionType.NotifyOnly, 1.0m, ApiUnit.Piece);
+        AutomationFunctions.ValidateActionType(AutomationActionType.NotifyOnly, 1.0m);
     }
 
     #endregion
@@ -732,8 +724,8 @@ public class AutomationFunctionsTests
     {
         AutomationFunctions.ValidateActionType(
             AutomationActionType.AddToShoppingList,
-            null, null,
-            Guid.NewGuid(), Guid.NewGuid(), 1.0m, ApiUnit.Piece);
+            null,
+            Guid.NewGuid(), Guid.NewGuid(), 1.0m);
     }
 
     [Fact]
@@ -742,8 +734,8 @@ public class AutomationFunctionsTests
         Assert.Throws<AutomationInvalidScheduleException>(() =>
             AutomationFunctions.ValidateActionType(
                 AutomationActionType.AddToShoppingList,
-                null, null,
-                null, Guid.NewGuid(), 1.0m, ApiUnit.Piece));
+                null,
+                null, Guid.NewGuid(), 1.0m));
     }
 
     [Fact]
@@ -752,8 +744,8 @@ public class AutomationFunctionsTests
         Assert.Throws<AutomationInvalidScheduleException>(() =>
             AutomationFunctions.ValidateActionType(
                 AutomationActionType.AddToShoppingList,
-                null, null,
-                Guid.NewGuid(), null, 1.0m, ApiUnit.Piece));
+                null,
+                Guid.NewGuid(), null, 1.0m));
     }
 
     [Fact]
@@ -762,8 +754,8 @@ public class AutomationFunctionsTests
         Assert.Throws<AutomationInvalidScheduleException>(() =>
             AutomationFunctions.ValidateActionType(
                 AutomationActionType.AddToShoppingList,
-                null, null,
-                Guid.NewGuid(), Guid.NewGuid(), null, ApiUnit.Piece));
+                null,
+                Guid.NewGuid(), Guid.NewGuid(), null));
     }
 
     [Fact]
@@ -772,18 +764,8 @@ public class AutomationFunctionsTests
         Assert.Throws<AutomationInvalidScheduleException>(() =>
             AutomationFunctions.ValidateActionType(
                 AutomationActionType.AddToShoppingList,
-                null, null,
-                Guid.NewGuid(), Guid.NewGuid(), 0m, ApiUnit.Piece));
-    }
-
-    [Fact]
-    public void ValidateActionType_AddToShoppingList_NoUnit_Throws()
-    {
-        Assert.Throws<AutomationInvalidScheduleException>(() =>
-            AutomationFunctions.ValidateActionType(
-                AutomationActionType.AddToShoppingList,
-                null, null,
-                Guid.NewGuid(), Guid.NewGuid(), 1.0m, null));
+                null,
+                Guid.NewGuid(), Guid.NewGuid(), 0m));
     }
 
     #endregion

--- a/Homassy.Tests/Unit/ItemAutomationTests.cs
+++ b/Homassy.Tests/Unit/ItemAutomationTests.cs
@@ -389,8 +389,7 @@ public class ItemAutomationTests
             IntervalDays = 7,
             ScheduledTime = new TimeOnly(8, 0),
             ActionType = AutomationActionType.AutoConsume,
-            ConsumeQuantity = 1.0m,
-            ConsumeUnit = ApiUnit.Piece
+            ConsumeQuantity = 1.0m
         };
 
         // Assert
@@ -399,7 +398,6 @@ public class ItemAutomationTests
         Assert.Equal(7, request.IntervalDays);
         Assert.Equal(AutomationActionType.AutoConsume, request.ActionType);
         Assert.Equal(1.0m, request.ConsumeQuantity);
-        Assert.Equal(ApiUnit.Piece, request.ConsumeUnit);
         Assert.False(request.IsSharedWithFamily);
     }
 
@@ -421,11 +419,9 @@ public class ItemAutomationTests
         Assert.Null(request.ScheduledDaysOfWeek);
         Assert.Null(request.ScheduledDayOfMonth);
         Assert.Null(request.ConsumeQuantity);
-        Assert.Null(request.ConsumeUnit);
         Assert.Null(request.ProductPublicId);
         Assert.Null(request.ShoppingListPublicId);
         Assert.Null(request.AddQuantity);
-        Assert.Null(request.AddUnit);
     }
 
     [Fact]
@@ -442,12 +438,10 @@ public class ItemAutomationTests
         Assert.Null(request.ScheduledTime);
         Assert.Null(request.ActionType);
         Assert.Null(request.ConsumeQuantity);
-        Assert.Null(request.ConsumeUnit);
         Assert.Null(request.IsEnabled);
         Assert.Null(request.ProductPublicId);
         Assert.Null(request.ShoppingListPublicId);
         Assert.Null(request.AddQuantity);
-        Assert.Null(request.AddUnit);
     }
 
     [Fact]
@@ -797,8 +791,7 @@ public class ItemAutomationTests
             ScheduledDaysOfWeek = DaysOfWeek.Monday | DaysOfWeek.Thursday,
             ScheduledTime = new TimeOnly(7, 0),
             ActionType = AutomationActionType.AddToShoppingList,
-            AddQuantity = 3m,
-            AddUnit = ApiUnit.Liter
+            AddQuantity = 3m
         };
 
         Assert.Null(request.InventoryItemPublicId);
@@ -807,7 +800,6 @@ public class ItemAutomationTests
         Assert.Equal(DaysOfWeek.Monday | DaysOfWeek.Thursday, request.ScheduledDaysOfWeek);
         Assert.Equal(AutomationActionType.AddToShoppingList, request.ActionType);
         Assert.Equal(3m, request.AddQuantity);
-        Assert.Equal(ApiUnit.Liter, request.AddUnit);
     }
 
     [Fact]
@@ -818,13 +810,11 @@ public class ItemAutomationTests
         var request = new UpdateAutomationRequest
         {
             ShoppingListPublicId = shoppingListPublicId,
-            AddQuantity = 5m,
-            AddUnit = ApiUnit.Kilogram
+            AddQuantity = 5m
         };
 
         Assert.Equal(shoppingListPublicId, request.ShoppingListPublicId);
         Assert.Equal(5m, request.AddQuantity);
-        Assert.Equal(ApiUnit.Kilogram, request.AddUnit);
         Assert.Null(request.ScheduleType);
         Assert.Null(request.ActionType);
     }

--- a/Homassy.Web/app/components/InventoryItemDetail.vue
+++ b/Homassy.Web/app/components/InventoryItemDetail.vue
@@ -251,7 +251,7 @@
 
       <template #body>
         <div class="space-y-4">
-          <!-- Quantity -->
+          <!-- Quantity (unit is inherited from the product and not editable here) -->
           <div>
             <label class="block text-sm font-medium mb-1">
               {{ $t('pages.products.details.editModal.quantityLabel') }}
@@ -260,20 +260,12 @@
               v-model="editForm.quantity"
               type="number"
               :min="0"
-            />
-          </div>
-
-          <!-- Unit -->
-          <div>
-            <label class="block text-sm font-medium mb-1">
-              {{ $t('pages.products.details.editModal.unitLabel') }}
-            </label>
-            <USelect
-              :model-value="editForm.unit ?? undefined"
-              :items="unitOptions"
               class="w-full"
-              @update:model-value="(val) => editForm.unit = val ?? null"
-            />
+            >
+              <template #trailing>
+                <span class="text-sm text-gray-500 dark:text-gray-400">{{ $t(`enums.unit.${item.unit}`) }}</span>
+              </template>
+            </UInput>
           </div>
 
           <!-- Expiration Date -->
@@ -584,7 +576,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import type { InventoryItemInfo, ConsumeInventoryItemRequest, SplitInventoryItemRequest, UpdateInventoryItemRequest, MoveInventoryItemsRequest } from '../types/product'
-import { Unit, Currency, SelectValueType } from '../types/enums'
+import { Currency, SelectValueType } from '../types/enums'
 import type { SelectValue } from '../types/selectValue'
 import type { CalendarDate } from '@internationalized/date'
 import { CalendarDate as CalendarDateClass } from '@internationalized/date'
@@ -633,13 +625,11 @@ const isEditModalOpen = ref(false)
 const expirationDateInput = ref()
 const editForm = ref<{
   quantity: number | null
-  unit: Unit | null
   expirationAt: CalendarDate | null
   price: number | null
   currency: Currency | null
 }>({
   quantity: null,
-  unit: null,
   expirationAt: null,
   price: null,
   currency: null
@@ -685,15 +675,6 @@ const dropdownItems = computed(() => [
 ])
 
 // Select options
-const unitOptions = computed(() => {
-  return Object.entries(Unit)
-    .filter(([key]) => isNaN(Number(key))) // Filter out numeric keys
-    .map(([_key, value]) => ({
-      label: $t(`enums.unit.${value}`),
-      value: value as Unit
-    }))
-})
-
 const currencyOptions = computed(() => [
   { label: $t('enums.currency.135'), value: Currency.Huf },
   { label: $t('enums.currency.105'), value: Currency.Eur },
@@ -852,7 +833,6 @@ const openEditModal = () => {
 
   editForm.value = {
     quantity: props.item.currentQuantity,
-    unit: props.item.unit,
     expirationAt: expirationDate,
     price: props.item.purchaseInfo?.price || null,
     currency: props.item.purchaseInfo?.currency || null
@@ -864,7 +844,6 @@ const closeEditModal = () => {
   isEditModalOpen.value = false
   editForm.value = {
     quantity: null,
-    unit: null,
     expirationAt: null,
     price: null,
     currency: null
@@ -885,7 +864,6 @@ const handleUpdate = async () => {
 
     const request: UpdateInventoryItemRequest = {
       quantity: editForm.value.quantity || undefined,
-      unit: editForm.value.unit || undefined,
       expirationAt: expirationAtString,
       price: editForm.value.price || undefined,
       currency: editForm.value.currency || undefined

--- a/Homassy.Web/app/components/ShoppingListItemCard.vue
+++ b/Homassy.Web/app/components/ShoppingListItemCard.vue
@@ -193,7 +193,7 @@
             />
           </div>
 
-          <!-- Quantity -->
+          <!-- Quantity (product-linked items show the product's unit as a suffix) -->
           <div>
             <label class="block text-sm font-medium mb-1">
               {{ $t('common.quantity') }}
@@ -204,11 +204,15 @@
               :min="0.001"
               step="0.1"
               class="w-full"
-            />
+            >
+              <template v-if="item.productPublicId && unitLabel" #trailing>
+                <span class="text-sm text-gray-500 dark:text-gray-400">{{ unitLabel }}</span>
+              </template>
+            </UInput>
           </div>
 
-          <!-- Unit -->
-          <div>
+          <!-- Unit (only editable for standalone/custom items) -->
+          <div v-if="!item.productPublicId">
             <label class="block text-sm font-medium mb-1">
               {{ $t('common.unit') }}
             </label>

--- a/Homassy.Web/app/pages/products/[publicId].vue
+++ b/Homassy.Web/app/pages/products/[publicId].vue
@@ -109,6 +109,19 @@
             />
           </div>
 
+          <!-- Unit -->
+          <div>
+            <label class="block text-sm font-medium mb-1">
+              {{ $t('pages.addProduct.form.unit') }} <span class="text-red-500">*</span>
+            </label>
+            <USelect
+              v-model="editProductForm.unit"
+              :items="unitOptions"
+              :placeholder="$t('pages.addProduct.form.unitPlaceholder')"
+              class="w-full"
+            />
+          </div>
+
           <!-- Barcode -->
           <div>
             <label class="block text-sm font-medium mb-1">
@@ -358,6 +371,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import type { DetailedProductInfo, UpdateProductRequest } from '../../types/product'
+import { Unit } from '../../types/enums'
 import type { OpenFoodFactsProduct } from '../../types/openFoodFacts'
 import { useProductsApi } from '../../composables/api/useProductsApi'
 import { useOpenFoodFactsApi } from '../../composables/api/useOpenFoodFactsApi'
@@ -393,11 +407,22 @@ const editProductForm = ref<UpdateProductRequest>({
   name: undefined,
   brand: undefined,
   category: undefined,
+  unit: undefined,
   barcode: undefined,
   isEatable: undefined,
   notes: undefined
 })
 const isUpdatingProduct = ref(false)
+
+// Unit options for the product edit form
+const unitOptions = computed(() => {
+  return Object.entries(Unit)
+    .filter(([key]) => isNaN(Number(key)))
+    .map(([_key, value]) => ({
+      label: $t(`enums.unit.${value}`),
+      value: value as Unit
+    }))
+})
 
 // OpenFoodFacts state for edit modal
 const isOpenFoodFactsModalOpen = ref(false)
@@ -662,6 +687,7 @@ const openEditProductModal = () => {
     name: product.value.name,
     brand: product.value.brand,
     category: product.value.category || undefined,
+    unit: product.value.unit,
     barcode: product.value.barcode || undefined,
     isEatable: product.value.isEatable,
     notes: undefined // Notes not available in DetailedProductInfo
@@ -675,6 +701,7 @@ const closeEditProductModal = () => {
     name: undefined,
     brand: undefined,
     category: undefined,
+    unit: undefined,
     barcode: undefined,
     isEatable: undefined,
     notes: undefined

--- a/Homassy.Web/app/pages/products/add-product.vue
+++ b/Homassy.Web/app/pages/products/add-product.vue
@@ -123,6 +123,16 @@
                   />
                 </UFormField>
 
+                <UFormField :label="t('pages.addProduct.form.unit')" name="unit" required>
+                  <USelect
+                    v-model="formData.unit"
+                    :items="unitOptions"
+                    :placeholder="t('pages.addProduct.form.unitPlaceholder')"
+                    :disabled="isCreating"
+                    class="w-full"
+                  />
+                </UFormField>
+
                 <UFormField :label="t('pages.addProduct.form.barcode')" name="barcode">
                   <UFieldGroup size="md" orientation="horizontal" class="w-full">
                     <UInput
@@ -687,7 +697,7 @@
             :state="inventoryFormData"
             class="space-y-4"
           >
-            <!-- Quantity (Required) -->
+            <!-- Quantity (Required) — unit is inherited from the product -->
             <UFormField :label="t('pages.addProduct.inventory.form.quantity')" name="quantity" required>
             <UInput
               v-model.number="inventoryFormData.quantity"
@@ -697,18 +707,11 @@
               :placeholder="t('pages.addProduct.inventory.form.quantityPlaceholder')"
               :disabled="isCreatingInventory"
               class="w-full"
-            />
-          </UFormField>
-
-          <!-- Unit (Required) -->
-          <UFormField :label="t('pages.addProduct.inventory.form.unit')" name="unit" required>
-            <USelect
-              v-model="inventoryFormData.unit"
-              :items="unitOptions"
-              :placeholder="t('pages.addProduct.inventory.form.unitPlaceholder')"
-              :disabled="isCreatingInventory"
-              class="w-full"
-            />
+            >
+              <template v-if="productUnitLabel" #trailing>
+                <span class="text-sm text-gray-500 dark:text-gray-400">{{ productUnitLabel }}</span>
+              </template>
+            </UInput>
           </UFormField>
 
           <!-- Expiration Date (Optional) -->
@@ -898,28 +901,21 @@
             class="space-y-4"
             @submit="onAddIndividualItem"
           >
-            <!-- Quantity + Unit (side by side) -->
-            <div class="grid grid-cols-2 gap-4">
-              <UFormField :label="t('pages.addProduct.inventory.form.quantity')" name="quantity" required>
-                <UInput
-                  v-model.number="inventoryFormData.quantity"
-                  type="number"
-                  step="0.01"
-                  min="0.01"
-                  :placeholder="t('pages.addProduct.inventory.form.quantityPlaceholder')"
-                  class="w-full"
-                />
-              </UFormField>
-
-              <UFormField :label="t('pages.addProduct.inventory.form.unit')" name="unit" required>
-                <USelect
-                  v-model="inventoryFormData.unit"
-                  :items="unitOptions"
-                  :placeholder="t('pages.addProduct.inventory.form.unitPlaceholder')"
-                  class="w-full"
-                />
-              </UFormField>
-            </div>
+            <!-- Quantity (unit is inherited from the product) -->
+            <UFormField :label="t('pages.addProduct.inventory.form.quantity')" name="quantity" required>
+              <UInput
+                v-model.number="inventoryFormData.quantity"
+                type="number"
+                step="0.01"
+                min="0.01"
+                :placeholder="t('pages.addProduct.inventory.form.quantityPlaceholder')"
+                class="w-full"
+              >
+                <template v-if="productUnitLabel" #trailing>
+                  <span class="text-sm text-gray-500 dark:text-gray-400">{{ productUnitLabel }}</span>
+                </template>
+              </UInput>
+            </UFormField>
 
             <!-- Expiration Date -->
             <UFormField :label="t('pages.addProduct.inventory.form.expirationAt')" name="expirationAt">
@@ -1206,6 +1202,7 @@ const formData = ref<CreateProductRequest>({
   name: '',
   brand: '',
   category: undefined,
+  unit: Unit.Piece,
   barcode: '',
   isEatable: false,
   notes: '',
@@ -1300,6 +1297,16 @@ const unitOptions = computed(() => {
     }))
 })
 
+// The inventory created in this flow always inherits the product's unit.
+const productUnitLabel = computed(() =>
+  formData.value.unit !== undefined ? t(`enums.unit.${formData.value.unit}`) : ''
+)
+
+// Keep the inventory form/items in sync with the chosen product unit.
+watch(() => formData.value.unit, (unit) => {
+  inventoryFormData.value.unit = unit
+}, { immediate: true })
+
 // Currency options for dropdown
 const currencyOptions = computed(() => {
   return [
@@ -1316,6 +1323,7 @@ const createProductSchema = z.object({
   brand: z.string({ required_error: 'A márka kötelező' })
     .min(1, 'A márka kötelező'),
   category: z.nativeEnum(ProductCategory).optional(),
+  unit: z.nativeEnum(Unit, { required_error: 'Unit is required' }),
   barcode: z.string().optional(),
   isEatable: z.boolean().optional().default(false),
   notes: z.string().optional(),
@@ -1767,6 +1775,7 @@ const onCreateProduct = async (event: FormSubmitEvent<CreateProductSchema>) => {
       name: event.data.name,
       brand: event.data.brand,
       category: event.data.category || null,
+      unit: event.data.unit,
       barcode: event.data.barcode?.trim() || null,
       notes: event.data.notes?.trim() || null,
       isEatable: event.data.isEatable,
@@ -1885,7 +1894,7 @@ const resetInventoryForm = () => {
   inventoryFormData.value = {
     productPublicId: '',
     quantity: 1,
-    unit: undefined,
+    unit: formData.value.unit,
     expirationAt: null,
     price: undefined,
     currency: undefined,
@@ -1943,7 +1952,6 @@ const buildInventoryRequest = (itemData: IndividualInventoryItem | InventoryForm
     storageLocationPublicId: selectedStorageLocationId.value || undefined,
     shoppingLocationPublicId: selectedShoppingLocationId.value || undefined,
     quantity: itemData.quantity,
-    unit: itemData.unit!,
     expirationAt: convertCalendarDateToISO(itemData.expirationAt || null),
     price: itemData.price && itemData.price > 0 ? itemData.price : undefined,
     currency: itemData.price && itemData.price > 0 ? itemData.currency : undefined,
@@ -2139,7 +2147,6 @@ const onCreateInventory = async (event: FormSubmitEvent<CreateInventorySchema>) 
       storageLocationPublicId: selectedStorageLocationId.value || undefined,
       shoppingLocationPublicId: selectedShoppingLocationId.value || undefined,
       quantity: event.data.quantity,
-      unit: event.data.unit,
       expirationAt: expirationAtString,
       price: event.data.price,
       currency: event.data.currency,

--- a/Homassy.Web/app/pages/profile/automation/[publicId].vue
+++ b/Homassy.Web/app/pages/profile/automation/[publicId].vue
@@ -362,23 +362,17 @@
           <label class="block text-sm font-medium mb-1">
             {{ $t('common.quantity') }}
           </label>
-          <div class="flex gap-2">
-            <UInput
-              v-model.number="form.consumeQuantity"
-              type="number"
-              :min="0.001"
-              step="0.1"
-              class="flex-1"
-            />
-            <USelect
-              v-model="form.consumeUnit"
-              :items="unitOptions"
-              value-key="value"
-              label-key="label"
-              :placeholder="$t('common.unit')"
-              class="w-32"
-            />
-          </div>
+          <UInput
+            v-model.number="form.consumeQuantity"
+            type="number"
+            :min="0.001"
+            step="0.1"
+            class="w-full"
+          >
+            <template v-if="unitLabel" #trailing>
+              <span class="text-sm text-gray-500 dark:text-gray-400">{{ unitLabel }}</span>
+            </template>
+          </UInput>
         </div>
 
         <!-- Add Quantity -->
@@ -386,23 +380,17 @@
           <label class="block text-sm font-medium mb-1">
             {{ $t('profile.automation.addQuantity') }} <span class="text-red-500">*</span>
           </label>
-          <div class="flex gap-2">
-            <UInput
-              v-model.number="form.addQuantity"
-              type="number"
-              :min="0.001"
-              step="0.1"
-              class="flex-1"
-            />
-            <USelect
-              v-model="form.addUnit"
-              :items="unitOptions"
-              value-key="value"
-              label-key="label"
-              :placeholder="$t('common.unit')"
-              class="w-32"
-            />
-          </div>
+          <UInput
+            v-model.number="form.addQuantity"
+            type="number"
+            :min="0.001"
+            step="0.1"
+            class="w-full"
+          >
+            <template v-if="unitLabel" #trailing>
+              <span class="text-sm text-gray-500 dark:text-gray-400">{{ unitLabel }}</span>
+            </template>
+          </UInput>
         </div>
       </div>
     </template>
@@ -468,7 +456,6 @@ import type {
   AutomationExecutionResponse,
   UpdateAutomationRequest
 } from '~/types/automation'
-import { Unit } from '~/types/enums'
 
 definePageMeta({ layout: 'auth', middleware: 'auth' })
 
@@ -528,9 +515,7 @@ const defaultForm = () => ({
   scheduledTime: '07:00',
   actionType: AutomationActionType.AutoConsume as AutomationActionType,
   consumeQuantity: undefined as number | undefined,
-  consumeUnit: undefined as number | undefined,
   addQuantity: undefined as number | undefined,
-  addUnit: undefined as number | undefined,
   thresholdQuantity: undefined as number | undefined
 })
 const form = ref(defaultForm())
@@ -638,14 +623,11 @@ const daysOfWeekOptions = computed(() => [
   { value: DaysOfWeek.Sunday, label: t('profile.automation.days.sunday') }
 ])
 
-const unitOptions = computed(() =>
-  Object.entries(Unit)
-    .filter(([_key]) => isNaN(Number(_key)))
-    .map(([_key, value]) => ({
-      value: value as number,
-      label: t(`enums.unit.${value}`)
-    }))
-)
+// The automation's unit is inherited from the product; shown read-only as a suffix.
+const unitLabel = computed(() => {
+  const unit = automation.value?.consumeUnit ?? automation.value?.addUnit
+  return unit !== undefined ? t(`enums.unit.${unit}`) : ''
+})
 
 // Helpers
 function getSelectedDayNames(flags: number): string {
@@ -887,9 +869,7 @@ async function openEditModal() {
     scheduledTime: automation.value.scheduledTime,
     actionType: automation.value.actionType,
     consumeQuantity: automation.value.consumeQuantity,
-    consumeUnit: automation.value.consumeUnit,
     addQuantity: automation.value.addQuantity,
-    addUnit: automation.value.addUnit,
     thresholdQuantity: automation.value.thresholdQuantity
   }
   isEditModalOpen.value = true
@@ -971,9 +951,7 @@ async function handleSave() {
       scheduledTime: isLowStockAction ? '00:00' : form.value.scheduledTime,
       actionType: form.value.actionType,
       consumeQuantity: form.value.actionType === AutomationActionType.AutoConsume ? form.value.consumeQuantity : undefined,
-      consumeUnit: form.value.actionType === AutomationActionType.AutoConsume ? form.value.consumeUnit : undefined,
       addQuantity: isShoppingListAction ? form.value.addQuantity : undefined,
-      addUnit: isShoppingListAction ? form.value.addUnit : undefined,
       shoppingListPublicId: isShoppingListAction ? form.value.shoppingListPublicId : undefined,
       productPublicId: isShoppingListAction ? form.value.productPublicId : undefined,
       thresholdQuantity: isLowStockAction ? form.value.thresholdQuantity : undefined

--- a/Homassy.Web/app/pages/profile/automation/create.vue
+++ b/Homassy.Web/app/pages/profile/automation/create.vue
@@ -313,23 +313,17 @@
             <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
               {{ t('profile.automation.create.lowStockAddQuantityDescription') }}
             </p>
-            <div class="flex gap-2">
-              <UInput
-                v-model.number="form.addQuantity"
-                type="number"
-                :min="0.001"
-                step="0.1"
-                class="flex-1"
-              />
-              <USelect
-                v-model="form.addUnit"
-                :items="unitOptions"
-                value-key="value"
-                label-key="label"
-                :placeholder="t('common.unit')"
-                class="w-32"
-              />
-            </div>
+            <UInput
+              v-model.number="form.addQuantity"
+              type="number"
+              :min="0.001"
+              step="0.1"
+              class="w-full"
+            >
+              <template v-if="selectedUnitLabel" #trailing>
+                <span class="text-sm text-gray-500 dark:text-gray-400">{{ selectedUnitLabel }}</span>
+              </template>
+            </UInput>
           </div>
         </div>
 
@@ -353,23 +347,17 @@
             <label class="block text-sm font-medium mb-1">
               {{ t('common.quantity') }}
             </label>
-            <div class="flex gap-2">
-              <UInput
-                v-model.number="form.consumeQuantity"
-                type="number"
-                :min="0.001"
-                step="0.1"
-                class="flex-1"
-              />
-              <USelect
-                v-model="form.consumeUnit"
-                :items="unitOptions"
-                value-key="value"
-                label-key="label"
-                :placeholder="t('common.unit')"
-                class="w-32"
-              />
-            </div>
+            <UInput
+              v-model.number="form.consumeQuantity"
+              type="number"
+              :min="0.001"
+              step="0.1"
+              class="w-full"
+            >
+              <template v-if="selectedUnitLabel" #trailing>
+                <span class="text-sm text-gray-500 dark:text-gray-400">{{ selectedUnitLabel }}</span>
+              </template>
+            </UInput>
           </div>
 
           <!-- Add Quantity (for AddToShoppingList) -->
@@ -377,23 +365,17 @@
             <label class="block text-sm font-medium mb-1">
               {{ t('profile.automation.addQuantity') }} <span class="text-red-500">*</span>
             </label>
-            <div class="flex gap-2">
-              <UInput
-                v-model.number="form.addQuantity"
-                type="number"
-                :min="0.001"
-                step="0.1"
-                class="flex-1"
-              />
-              <USelect
-                v-model="form.addUnit"
-                :items="unitOptions"
-                value-key="value"
-                label-key="label"
-                :placeholder="t('common.unit')"
-                class="w-32"
-              />
-            </div>
+            <UInput
+              v-model.number="form.addQuantity"
+              type="number"
+              :min="0.001"
+              step="0.1"
+              class="w-full"
+            >
+              <template v-if="selectedUnitLabel" #trailing>
+                <span class="text-sm text-gray-500 dark:text-gray-400">{{ selectedUnitLabel }}</span>
+              </template>
+            </UInput>
           </div>
           <div class="flex items-center gap-2">
             <UCheckbox
@@ -443,17 +425,17 @@
 
             <div v-if="form.actionType === AutomationActionType.AutoConsume && form.consumeQuantity" class="flex justify-between text-sm">
               <span class="text-gray-500 dark:text-gray-400">{{ t('common.quantity') }}</span>
-              <span class="font-medium">{{ form.consumeQuantity }} {{ form.consumeUnit !== undefined ? t(`enums.unit.${form.consumeUnit}`) : '' }}</span>
+              <span class="font-medium">{{ form.consumeQuantity }} {{ selectedUnitLabel }}</span>
             </div>
 
             <div v-if="form.actionType === AutomationActionType.AddToShoppingList && form.addQuantity" class="flex justify-between text-sm">
               <span class="text-gray-500 dark:text-gray-400">{{ t('profile.automation.addQuantity') }}</span>
-              <span class="font-medium">{{ form.addQuantity }} {{ form.addUnit !== undefined ? t(`enums.unit.${form.addUnit}`) : '' }}</span>
+              <span class="font-medium">{{ form.addQuantity }} {{ selectedUnitLabel }}</span>
             </div>
 
             <div v-if="form.actionType === AutomationActionType.LowStockAddToShoppingList && form.addQuantity" class="flex justify-between text-sm">
               <span class="text-gray-500 dark:text-gray-400">{{ t('profile.automation.addQuantity') }}</span>
-              <span class="font-medium">{{ form.addQuantity }} {{ form.addUnit !== undefined ? t(`enums.unit.${form.addUnit}`) : '' }}</span>
+              <span class="font-medium">{{ form.addQuantity }} {{ selectedUnitLabel }}</span>
             </div>
           </div>
         </div>
@@ -485,7 +467,6 @@ import {
 import type { CreateAutomationRequest } from '~/types/automation'
 import type { ProductInfo, DetailedProductInfo } from '~/types/product'
 import type { ShoppingListInfo } from '~/types/shoppingList'
-import { Unit } from '~/types/enums'
 
 definePageMeta({ layout: 'auth', middleware: 'auth' })
 
@@ -535,9 +516,7 @@ const form = ref({
   scheduledDayOfMonth: undefined as number | undefined,
   scheduledTime: '07:00',
   consumeQuantity: undefined as number | undefined,
-  consumeUnit: undefined as number | undefined,
   addQuantity: undefined as number | undefined,
-  addUnit: undefined as number | undefined,
   thresholdQuantity: undefined as number | undefined,
   isSharedWithFamily: false
 })
@@ -606,13 +585,13 @@ const daysOfWeekOptions = computed(() => [
   { value: DaysOfWeek.Sunday, label: t('profile.automation.days.sunday') }
 ])
 
-const unitOptions = computed(() =>
-  Object.entries(Unit)
-    .filter(([key]) => isNaN(Number(key)))
-    .map(([_key, value]) => ({
-      value: value as number,
-      label: t(`enums.unit.${value}`)
-    }))
+// The automation's unit is always inherited from the selected product.
+const selectedProductUnit = computed(() => {
+  const product = productSearchResults.value.find((p: ProductInfo) => p.publicId === form.value.productPublicId)
+  return product?.unit
+})
+const selectedUnitLabel = computed(() =>
+  selectedProductUnit.value !== undefined ? t(`enums.unit.${selectedProductUnit.value}`) : ''
 )
 
 // Computed labels for summary
@@ -874,9 +853,7 @@ async function handleCreate() {
       scheduledTime: needsSchedule ? form.value.scheduledTime : '00:00',
       actionType: form.value.actionType,
       consumeQuantity: form.value.actionType === AutomationActionType.AutoConsume ? form.value.consumeQuantity : undefined,
-      consumeUnit: form.value.actionType === AutomationActionType.AutoConsume ? form.value.consumeUnit : undefined,
       addQuantity: needsProduct ? form.value.addQuantity : undefined,
-      addUnit: needsProduct ? form.value.addUnit : undefined,
       thresholdQuantity: isLowStockType ? form.value.thresholdQuantity : undefined,
       isSharedWithFamily: form.value.isSharedWithFamily
     }

--- a/Homassy.Web/app/pages/shopping-lists/add-product.vue
+++ b/Homassy.Web/app/pages/shopping-lists/add-product.vue
@@ -123,6 +123,16 @@
                   />
                 </UFormField>
 
+                <UFormField :label="t('pages.addProduct.form.unit')" name="unit" required>
+                  <USelect
+                    v-model="productFormData.unit"
+                    :items="unitOptions"
+                    :placeholder="t('pages.addProduct.form.unitPlaceholder')"
+                    :disabled="isCreating"
+                    class="w-full"
+                  />
+                </UFormField>
+
                 <UFormField :label="t('pages.addProduct.form.barcode')" name="barcode">
                   <UFieldGroup size="md" orientation="horizontal" class="w-full">
                     <UInput
@@ -439,10 +449,20 @@
               :placeholder="t('pages.shoppingLists.addProduct.item.quantityPlaceholder')"
               :disabled="isCreatingItem"
               class="w-full"
-            />
+            >
+              <template v-if="productSelectionMode === 'product' && selectedProductUnit !== undefined" #trailing>
+                <span class="text-sm text-gray-500 dark:text-gray-400">{{ t(`enums.unit.${selectedProductUnit}`) }}</span>
+              </template>
+            </UInput>
           </UFormField>
 
-          <UFormField :label="t('pages.shoppingLists.addProduct.item.unitLabel')" name="unit" required>
+          <!-- Unit is only chosen for standalone/custom items; product items inherit it -->
+          <UFormField
+            v-if="productSelectionMode === 'custom'"
+            :label="t('pages.shoppingLists.addProduct.item.unitLabel')"
+            name="unit"
+            required
+          >
             <USelect
               v-model="itemFormData.unit"
               :items="unitOptions"
@@ -677,6 +697,8 @@ const tabItems = computed(() => [
 // Product Selection Mode
 const productSelectionMode = ref<'product' | 'custom' | null>(null)
 const selectedProductId = ref<string | null>(null)
+// Unit of the selected/created product — used to show a read-only suffix in product mode.
+const selectedProductUnit = ref<Unit | undefined>(undefined)
 const customProductName = ref<string>('')
 const selectedCardId = ref<string | null>(null)
 
@@ -690,6 +712,7 @@ const productFormData = ref<CreateProductRequest>({
   name: '',
   brand: '',
   category: undefined,
+  unit: Unit.Piece,
   barcode: '',
   isEatable: false,
   notes: '',
@@ -765,6 +788,7 @@ const createProductSchema = z.object({
   name: z.string().min(2, 'Name must be at least 2 characters').max(128, 'Name must not exceed 128 characters'),
   brand: z.string().min(2, 'Brand must be at least 2 characters').max(128, 'Brand must not exceed 128 characters'),
   category: z.nativeEnum(ProductCategory).optional(),
+  unit: z.nativeEnum(Unit, { required_error: 'Unit is required' }),
   barcode: z.string().max(50, 'Barcode must not exceed 50 characters').optional().or(z.literal('')),
   isEatable: z.boolean().optional().default(false),
   notes: z.string().max(500, 'Notes must not exceed 500 characters').optional().or(z.literal('')),
@@ -790,7 +814,8 @@ const createShoppingLocationSchema = z.object({
 
 const createShoppingListItemSchema = z.object({
   quantity: z.number({ required_error: 'Quantity is required' }).min(0.001, 'Quantity must be greater than 0'),
-  unit: z.nativeEnum(Unit, { required_error: 'Unit is required' }),
+  // Unit is only required for standalone/custom items; product items inherit the product's unit.
+  unit: z.nativeEnum(Unit).optional(),
   note: z.string().max(500, 'Note must not exceed 500 characters').optional(),
   deadlineAt: z.any().nullable().optional(),
   dueAt: z.any().nullable().optional()
@@ -945,6 +970,7 @@ onMounted(() => {
 const onProductCardClick = (product: ProductInfo) => {
   selectedCardId.value = product.publicId
   selectedProductId.value = product.publicId
+  selectedProductUnit.value = product.unit
   customProductName.value = ''
   productSelectionMode.value = 'product'
   currentStep.value = 1
@@ -958,6 +984,7 @@ const onCreateProduct = async (event: FormSubmitEvent<typeof createProductSchema
       name: event.data.name,
       brand: event.data.brand,
       category: event.data.category || undefined,
+      unit: event.data.unit,
       barcode: event.data.barcode || undefined,
       isEatable: event.data.isEatable || false,
       notes: event.data.notes || undefined,
@@ -967,6 +994,7 @@ const onCreateProduct = async (event: FormSubmitEvent<typeof createProductSchema
     const response = await createProduct(productData)
     if (response.success && response.data) {
       selectedProductId.value = response.data.publicId
+      selectedProductUnit.value = response.data.unit
       customProductName.value = ''
       productSelectionMode.value = 'product'
       currentStep.value = 1
@@ -1048,6 +1076,7 @@ const activeBarcodeHandler = computed(() => {
 const onCustomNameSubmit = (event: FormSubmitEvent<typeof customNameSchema>) => {
   customProductName.value = event.data.customName
   selectedProductId.value = null
+  selectedProductUnit.value = undefined
   productSelectionMode.value = 'custom'
   currentStep.value = 1
 }
@@ -1133,7 +1162,8 @@ const onCreateShoppingListItem = async (event: FormSubmitEvent<typeof createShop
       customName: productSelectionMode.value === 'custom' ? customProductName.value : undefined,
       shoppingLocationPublicId: selectedShoppingLocationId.value || undefined,
       quantity: event.data.quantity,
-      unit: event.data.unit,
+      // Product items inherit the product's unit server-side; only send it for custom items.
+      unit: productSelectionMode.value === 'custom' ? event.data.unit : undefined,
       note: event.data.note?.trim() || undefined,
       deadlineAt: deadlineAtString,
       dueAt: dueAtString

--- a/Homassy.Web/app/types/automation.ts
+++ b/Homassy.Web/app/types/automation.ts
@@ -92,9 +92,7 @@ export interface CreateAutomationRequest {
   scheduledTime: string
   actionType: AutomationActionType
   consumeQuantity?: number
-  consumeUnit?: Unit
   addQuantity?: number
-  addUnit?: Unit
   thresholdQuantity?: number
   isSharedWithFamily?: boolean
 }
@@ -107,9 +105,7 @@ export interface UpdateAutomationRequest {
   scheduledTime?: string
   actionType?: AutomationActionType
   consumeQuantity?: number
-  consumeUnit?: Unit
   addQuantity?: number
-  addUnit?: Unit
   thresholdQuantity?: number
   shoppingListPublicId?: string
   productPublicId?: string

--- a/Homassy.Web/app/types/product.ts
+++ b/Homassy.Web/app/types/product.ts
@@ -12,6 +12,7 @@ export interface ProductInfo {
   name: string
   brand: string
   category?: string
+  unit: Unit
   barcode?: string
   productPictureBase64?: string
   isEatable: boolean
@@ -26,6 +27,7 @@ export interface CreateProductRequest {
   name: string
   brand: string
   category?: string | null
+  unit: Unit
   barcode?: string | null
   isEatable?: boolean
   notes?: string | null
@@ -36,6 +38,7 @@ export interface UpdateProductRequest {
   name?: string
   brand?: string
   category?: string
+  unit?: Unit
   barcode?: string
   isEatable?: boolean
   notes?: string
@@ -100,7 +103,6 @@ export interface CreateInventoryItemRequest {
   isSharedWithFamily?: boolean
   storageLocationPublicId?: string
   quantity: number
-  unit?: Unit
   expirationAt?: string
   price?: number
   currency?: Currency
@@ -112,7 +114,6 @@ export interface UpdateInventoryItemRequest {
   isSharedWithFamily?: boolean
   storageLocationPublicId?: string
   quantity?: number
-  unit?: Unit
   expirationAt?: string
   price?: number
   currency?: Currency
@@ -123,14 +124,12 @@ export interface UpdateInventoryItemRequest {
 export interface QuickAddInventoryItemRequest {
   productPublicId: string
   quantity: number
-  unit?: Unit
   isSharedWithFamily?: boolean
 }
 
 export interface QuickAddMultipleInventoryItemEntry {
   productPublicId: string
   quantity: number
-  unit?: Unit
 }
 
 export interface QuickAddMultipleInventoryItemsRequest {

--- a/Homassy.Web/app/types/shoppingList.ts
+++ b/Homassy.Web/app/types/shoppingList.ts
@@ -53,7 +53,8 @@ export interface CreateShoppingListItemRequest {
   shoppingLocationPublicId?: string
   customName?: string
   quantity: number
-  unit: Unit
+  // Only used for standalone/custom items; product-linked items inherit the product's unit.
+  unit?: Unit
   note?: string
   deadlineAt?: string
   dueAt?: string
@@ -76,7 +77,8 @@ export interface CreateShoppingListItemEntry {
   shoppingLocationPublicId?: string
   customName?: string
   quantity: number
-  unit: Unit
+  // Only used for standalone/custom items; product-linked items inherit the product's unit.
+  unit?: Unit
   note?: string
   deadlineAt?: string
   dueAt?: string

--- a/Homassy.Web/i18n/locales/de.json
+++ b/Homassy.Web/i18n/locales/de.json
@@ -425,6 +425,8 @@
         "brandPlaceholder": "z.B. Mizo",
         "category": "Kategorie",
         "categoryPlaceholder": "z.B. Milchprodukte",
+        "unit": "Maßeinheit",
+        "unitPlaceholder": "Einheit wählen",
         "barcode": "Barcode",
         "barcodePlaceholder": "z.B. 5998200119874",
         "barcodeQuery": "Abfragen",

--- a/Homassy.Web/i18n/locales/en.json
+++ b/Homassy.Web/i18n/locales/en.json
@@ -427,6 +427,8 @@
         "brandPlaceholder": "e.g. Mizo",
         "category": "Category",
         "categoryPlaceholder": "e.g. Dairy",
+        "unit": "Unit of measure",
+        "unitPlaceholder": "Select unit",
         "barcode": "Barcode",
         "barcodePlaceholder": "e.g. 5998200119874",
         "barcodeQuery": "Query",

--- a/Homassy.Web/i18n/locales/hu.json
+++ b/Homassy.Web/i18n/locales/hu.json
@@ -428,6 +428,8 @@
         "brandPlaceholder": "pl. Mizo",
         "category": "Kategória",
         "categoryPlaceholder": "pl. Tejtermék",
+        "unit": "Mértékegység",
+        "unitPlaceholder": "Válassz mértékegységet",
         "barcode": "Vonalkód",
         "barcodePlaceholder": "pl. 5998200119874",
         "barcodeQuery": "Lekérdezés",


### PR DESCRIPTION
## Summary

- Every product now has its own `Unit` field; unit of measure is set once on the product and inherited by all inventory items, shopping list entries, and automations
- Unit selectors removed from inventory/quick-add forms, automation create/edit forms, and product-linked shopping list items — replaced with a localized read-only suffix (e.g. `500 ml`)
- Standalone (custom) shopping list items retain their own unit selector
- EF Core migration `AddUnitToProduct` adds the `Unit` column to `Products` (default `0` = Piece, covers all existing rows)
- All related tests updated to match the new DTO signatures

Closes #30