### PR TITLE
Clear shopping list item references on product delete

### DIFF
--- a/Homassy.API/Functions/ProductFunctions.cs
+++ b/Homassy.API/Functions/ProductFunctions.cs
@@ -756,6 +756,20 @@ namespace Homassy.API.Functions
                     Log.Information("Disabled automation {AutomationId} because product {ProductId} was deleted", automation.Id, product.Id);
                 }
 
+                // Clear ProductId on shopping list items referencing this product
+                var affectedShoppingListItems = await context.ShoppingListItems
+                    .Where(sli => sli.ProductId == product.Id && !sli.IsDeleted)
+                    .ToListAsync(cancellationToken);
+
+                foreach (var item in affectedShoppingListItems)
+                {
+                    if (string.IsNullOrWhiteSpace(item.CustomName))
+                        item.CustomName = product.Name;
+                    item.ProductId = null;
+                    item.UpdateRecordChange(userId.Value);
+                    Log.Information("Cleared ProductId on ShoppingListItem {ItemId} because product {ProductId} was deleted", item.Id, product.Id);
+                }
+
                 context.Products.Update(product);
                 await context.SaveChangesAsync(cancellationToken);
 

--- a/Homassy.API/Homassy.API.json
+++ b/Homassy.API/Homassy.API.json
@@ -11,7 +11,7 @@
       "name": "MIT License",
       "url": "https://github.com/Xentinus/Homassy/blob/master/LICENSE"
     },
-    "version": "26.0621.1708-dev"
+    "version": "26.0622.2047-dev"
   },
   "paths": {
     "/api/v1/Auth/me": {


### PR DESCRIPTION
## Summary

- When a product is deleted, `ShoppingListItem` records referencing that product now have their `ProductId` cleared within the same transaction
- If the item had no `CustomName`, it inherits the product's name so the user's shopping intent is preserved
- Fixes a bug where purchasing a shopping list item linked to a deleted product threw `ProductNotFoundException`, leaving the item in an unusable state

Closes #4