### PR TITLE
Expand family shopping list and inventory push notifications (#16)

### DIFF
--- a/Homassy.Notifications/CLAUDE.md
+++ b/Homassy.Notifications/CLAUDE.md
@@ -67,11 +67,13 @@ Homassy.Notifications/
 │   ├── IWebPushService.cs              # Push notification interface
 │   ├── WebPushService.cs               # VAPID push implementation
 │   ├── PushNotificationContentService.cs  # Localised notification text
+│   ├── FamilyPushNotifier.cs           # Shared recipient resolution + push dispatch
 │   ├── InventoryExpirationService.cs   # Expiring/expired item queries
 │   └── EmailServiceClient.cs           # HTTP client → Homassy.Email
 └── Workers/
     ├── PushNotificationSchedulerService.cs   # Hourly, Mon 07:00 → weekly push
     ├── ShoppingListActivityMonitorService.cs  # 5 min → shopping list push
+    ├── InventoryActivityMonitorService.cs     # 5 min → inventory (készlet) push
     └── EmailWeeklySummaryService.cs           # Hourly, Mon 07:00 → weekly email
 ```
 
@@ -120,8 +122,18 @@ builder.Services.AddDbContext<HomassyDbContext>(options =>
 
 ### ShoppingListActivityMonitorService
 - Runs every 5 minutes
-- Tracks in-memory shopping list sessions
-- Sends push notification when a new item is added while another device is active
+- Sends immediate notifications when a family shopping list is created or deleted
+- Tracks in-memory shopping list sessions (keyed by ShoppingListId); when item activity
+  (add/edit/delete/purchase) goes idle for 5 minutes, sends one notification per non-zero action
+  type to family members who did not contribute
+- Uses the shared `FamilyPushNotifier` for recipient resolution and dispatch
+
+### InventoryActivityMonitorService
+- Runs every 5 minutes
+- Tracks in-memory inventory sessions keyed by FamilyId; when inventory activity
+  (create/update/delete/consume) goes idle for 5 minutes, sends one notification per non-zero action
+  type (count-only, no product names) to family members who did not contribute
+- Uses the shared `FamilyPushNotifier`
 
 ### EmailWeeklySummaryService
 - Runs every hour

--- a/Homassy.Notifications/Program.cs
+++ b/Homassy.Notifications/Program.cs
@@ -34,12 +34,14 @@ try
 
     // Services
     builder.Services.AddSingleton<IWebPushService, WebPushService>();
+    builder.Services.AddSingleton<FamilyPushNotifier>();
     builder.Services.AddScoped<InventoryExpirationService>();
     builder.Services.AddHttpClient<EmailServiceClient>();
 
     // Background workers
     builder.Services.AddHostedService<PushNotificationSchedulerService>();
     builder.Services.AddHostedService<ShoppingListActivityMonitorService>();
+    builder.Services.AddHostedService<InventoryActivityMonitorService>();
     builder.Services.AddHostedService<EmailWeeklySummaryService>();
     builder.Services.AddHostedService<ItemAutomationWorkerService>();
 

--- a/Homassy.Notifications/Services/FamilyPushNotifier.cs
+++ b/Homassy.Notifications/Services/FamilyPushNotifier.cs
@@ -1,0 +1,106 @@
+using Homassy.API.Context;
+using Homassy.API.Enums;
+using Microsoft.EntityFrameworkCore;
+using Serilog;
+
+namespace Homassy.Notifications.Services;
+
+/// <summary>
+/// Shared helper for the family activity monitors. Resolves the family members eligible to receive a
+/// push notification and dispatches one or more localized notifications to them, cleaning up any
+/// subscription the push service reports as invalid.
+/// </summary>
+public sealed class FamilyPushNotifier
+{
+    private readonly IWebPushService _webPushService;
+
+    public FamilyPushNotifier(IWebPushService webPushService)
+    {
+        _webPushService = webPushService;
+    }
+
+    /// <summary>
+    /// Resolves the family members eligible to receive a notification: active members of the family
+    /// who have push notifications enabled and at least one active subscription, excluding the users
+    /// who performed the change.
+    /// </summary>
+    public async Task<List<RecipientInfo>> GetRecipientsAsync(
+        HomassyDbContext context,
+        int familyId,
+        IReadOnlyCollection<int> excludeUserIds,
+        CancellationToken cancellationToken)
+    {
+        return await context.Users
+            .AsNoTracking()
+            .Where(u => u.FamilyId == familyId
+                && !u.IsDeleted
+                && !excludeUserIds.Contains(u.Id)
+                && u.NotificationPreferences != null
+                && u.NotificationPreferences.PushNotificationsEnabled)
+            .Where(u => context.UserPushSubscriptions.Any(s => s.UserId == u.Id && !s.IsDeleted))
+            .Select(u => new RecipientInfo(
+                u.Id,
+                u.Profile != null ? u.Profile.DefaultLanguage : Language.Hungarian))
+            .ToListAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends one or more notifications (built per recipient language) to every recipient, cleaning up
+    /// any subscription the push service reports as invalid.
+    /// </summary>
+    public async Task DispatchAsync(
+        HomassyDbContext context,
+        IReadOnlyList<RecipientInfo> recipients,
+        Func<Language, IReadOnlyList<(string Title, string Body)>> contentFactory,
+        string url,
+        CancellationToken cancellationToken)
+    {
+        var hasChanges = false;
+
+        foreach (var recipient in recipients)
+        {
+            var notifications = contentFactory(recipient.Language);
+            if (notifications.Count == 0)
+                continue;
+
+            var actionTitle = GetActionTitle(recipient.Language);
+
+            var subscriptions = await context.UserPushSubscriptions
+                .Where(s => s.UserId == recipient.Id && !s.IsDeleted)
+                .ToListAsync(cancellationToken);
+
+            foreach (var subscription in subscriptions)
+            {
+                foreach (var (title, body) in notifications)
+                {
+                    var success = await _webPushService.SendNotificationAsync(
+                        subscription, title, body, url, actionTitle, cancellationToken);
+
+                    if (!success)
+                    {
+                        subscription.DeleteRecord();
+                        hasChanges = true;
+                        Log.Information(
+                            "Removed invalid push subscription {Endpoint} for user {UserId}",
+                            subscription.Endpoint, recipient.Id);
+                        break; // subscription is dead – skip its remaining notifications
+                    }
+                }
+            }
+        }
+
+        if (hasChanges)
+        {
+            await context.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private static string GetActionTitle(Language language) => language switch
+    {
+        Language.German => "Homassy öffnen",
+        Language.English => "Open Homassy",
+        _ => "Homassy megnyitása"
+    };
+}
+
+public readonly record struct RecipientInfo(int Id, Language Language);

--- a/Homassy.Notifications/Services/PushNotificationContentService.cs
+++ b/Homassy.Notifications/Services/PushNotificationContentService.cs
@@ -35,27 +35,244 @@ public static class PushNotificationContentService
         };
     }
 
-    public static (string Title, string Body) GetShoppingListActivityContent(Language language, string listName, int itemCount)
+    public static (string Title, string Body) GetShoppingListItemsAddedContent(
+        Language language, string listName, int count)
     {
         return language switch
         {
             Language.Hungarian => (
                 "Bevásárlólista frissítve",
-                itemCount == 1
-                    ? $"1 új elem került a(z) \"{listName}\" bevásárlólistához."
-                    : $"{itemCount} új elem került a(z) \"{listName}\" bevásárlólistához."
+                count == 1
+                    ? $"1 új elem került a(z) \"{listName}\" listához."
+                    : $"{count} új elem került a(z) \"{listName}\" listához."
             ),
             Language.German => (
                 "Einkaufsliste aktualisiert",
-                itemCount == 1
-                    ? $"1 neues Element wurde zur Einkaufsliste \"{listName}\" hinzugefügt."
-                    : $"{itemCount} neue Elemente wurden zur Einkaufsliste \"{listName}\" hinzugefügt."
+                count == 1
+                    ? $"1 neues Element wurde zur Liste \"{listName}\" hinzugefügt."
+                    : $"{count} neue Elemente wurden zur Liste \"{listName}\" hinzugefügt."
             ),
             _ => (
                 "Shopping List Updated",
-                itemCount == 1
-                    ? $"1 new item was added to the \"{listName}\" shopping list."
-                    : $"{itemCount} new items were added to the \"{listName}\" shopping list."
+                count == 1
+                    ? $"1 new item was added to the \"{listName}\" list."
+                    : $"{count} new items were added to the \"{listName}\" list."
+            )
+        };
+    }
+
+    public static (string Title, string Body) GetShoppingListItemsEditedContent(
+        Language language, string listName, int count)
+    {
+        return language switch
+        {
+            Language.Hungarian => (
+                "Bevásárlólista frissítve",
+                count == 1
+                    ? $"1 elem módosult a(z) \"{listName}\" listában."
+                    : $"{count} elem módosult a(z) \"{listName}\" listában."
+            ),
+            Language.German => (
+                "Einkaufsliste aktualisiert",
+                count == 1
+                    ? $"1 Element in der Liste \"{listName}\" wurde geändert."
+                    : $"{count} Elemente in der Liste \"{listName}\" wurden geändert."
+            ),
+            _ => (
+                "Shopping List Updated",
+                count == 1
+                    ? $"1 item was edited in the \"{listName}\" list."
+                    : $"{count} items were edited in the \"{listName}\" list."
+            )
+        };
+    }
+
+    public static (string Title, string Body) GetShoppingListItemsDeletedContent(
+        Language language, string listName, int count)
+    {
+        return language switch
+        {
+            Language.Hungarian => (
+                "Bevásárlólista frissítve",
+                count == 1
+                    ? $"1 elem törlődött a(z) \"{listName}\" listából."
+                    : $"{count} elem törlődött a(z) \"{listName}\" listából."
+            ),
+            Language.German => (
+                "Einkaufsliste aktualisiert",
+                count == 1
+                    ? $"1 Element wurde aus der Liste \"{listName}\" entfernt."
+                    : $"{count} Elemente wurden aus der Liste \"{listName}\" entfernt."
+            ),
+            _ => (
+                "Shopping List Updated",
+                count == 1
+                    ? $"1 item was removed from the \"{listName}\" list."
+                    : $"{count} items were removed from the \"{listName}\" list."
+            )
+        };
+    }
+
+    public static (string Title, string Body) GetShoppingListItemsPurchasedContent(
+        Language language, string listName, int count)
+    {
+        return language switch
+        {
+            Language.Hungarian => (
+                "Bevásárlólista frissítve",
+                count == 1
+                    ? $"1 elem megvásárolva a(z) \"{listName}\" listáról."
+                    : $"{count} elem megvásárolva a(z) \"{listName}\" listáról."
+            ),
+            Language.German => (
+                "Einkaufsliste aktualisiert",
+                count == 1
+                    ? $"1 Element aus der Liste \"{listName}\" wurde gekauft."
+                    : $"{count} Elemente aus der Liste \"{listName}\" wurden gekauft."
+            ),
+            _ => (
+                "Shopping List Updated",
+                count == 1
+                    ? $"1 item from the \"{listName}\" list was marked as purchased."
+                    : $"{count} items from the \"{listName}\" list were marked as purchased."
+            )
+        };
+    }
+
+    public static (string Title, string Body) GetShoppingListCreatedContent(Language language, string listName)
+    {
+        return language switch
+        {
+            Language.Hungarian => (
+                "Új bevásárlólista",
+                $"Új \"{listName}\" bevásárlólista jött létre a családodban."
+            ),
+            Language.German => (
+                "Neue Einkaufsliste",
+                $"Eine neue Einkaufsliste \"{listName}\" wurde in deiner Familie erstellt."
+            ),
+            _ => (
+                "New Shopping List",
+                $"A new \"{listName}\" shopping list was created in your family."
+            )
+        };
+    }
+
+    public static (string Title, string Body) GetShoppingListDeletedContent(Language language, string listName)
+    {
+        return language switch
+        {
+            Language.Hungarian => (
+                "Bevásárlólista törölve",
+                $"A(z) \"{listName}\" bevásárlólista törlődött a családodban."
+            ),
+            Language.German => (
+                "Einkaufsliste gelöscht",
+                $"Die Einkaufsliste \"{listName}\" wurde in deiner Familie gelöscht."
+            ),
+            _ => (
+                "Shopping List Deleted",
+                $"The \"{listName}\" shopping list was deleted in your family."
+            )
+        };
+    }
+
+    public static (string Title, string Body) GetInventoryItemsCreatedContent(Language language, int count)
+    {
+        return language switch
+        {
+            Language.Hungarian => (
+                "Készlet frissítve",
+                count == 1
+                    ? "1 új tétel került a készletbe."
+                    : $"{count} új tétel került a készletbe."
+            ),
+            Language.German => (
+                "Bestand aktualisiert",
+                count == 1
+                    ? "1 neuer Eintrag wurde zum Bestand hinzugefügt."
+                    : $"{count} neue Einträge wurden zum Bestand hinzugefügt."
+            ),
+            _ => (
+                "Inventory Updated",
+                count == 1
+                    ? "1 new item was added to the inventory."
+                    : $"{count} new items were added to the inventory."
+            )
+        };
+    }
+
+    public static (string Title, string Body) GetInventoryItemsUpdatedContent(Language language, int count)
+    {
+        return language switch
+        {
+            Language.Hungarian => (
+                "Készlet frissítve",
+                count == 1
+                    ? "1 készlettétel módosult."
+                    : $"{count} készlettétel módosult."
+            ),
+            Language.German => (
+                "Bestand aktualisiert",
+                count == 1
+                    ? "1 Bestandseintrag wurde geändert."
+                    : $"{count} Bestandseinträge wurden geändert."
+            ),
+            _ => (
+                "Inventory Updated",
+                count == 1
+                    ? "1 inventory item was updated."
+                    : $"{count} inventory items were updated."
+            )
+        };
+    }
+
+    public static (string Title, string Body) GetInventoryItemsDeletedContent(Language language, int count)
+    {
+        return language switch
+        {
+            Language.Hungarian => (
+                "Készlet frissítve",
+                count == 1
+                    ? "1 tétel törlődött a készletből."
+                    : $"{count} tétel törlődött a készletből."
+            ),
+            Language.German => (
+                "Bestand aktualisiert",
+                count == 1
+                    ? "1 Eintrag wurde aus dem Bestand entfernt."
+                    : $"{count} Einträge wurden aus dem Bestand entfernt."
+            ),
+            _ => (
+                "Inventory Updated",
+                count == 1
+                    ? "1 item was removed from the inventory."
+                    : $"{count} items were removed from the inventory."
+            )
+        };
+    }
+
+    public static (string Title, string Body) GetInventoryItemsConsumedContent(Language language, int count)
+    {
+        return language switch
+        {
+            Language.Hungarian => (
+                "Készlet frissítve",
+                count == 1
+                    ? "1 tétel felhasználva a készletből."
+                    : $"{count} tétel felhasználva a készletből."
+            ),
+            Language.German => (
+                "Bestand aktualisiert",
+                count == 1
+                    ? "1 Eintrag wurde aus dem Bestand verbraucht."
+                    : $"{count} Einträge wurden aus dem Bestand verbraucht."
+            ),
+            _ => (
+                "Inventory Updated",
+                count == 1
+                    ? "1 item was consumed from the inventory."
+                    : $"{count} items were consumed from the inventory."
             )
         };
     }

--- a/Homassy.Notifications/Workers/InventoryActivityMonitorService.cs
+++ b/Homassy.Notifications/Workers/InventoryActivityMonitorService.cs
@@ -1,0 +1,213 @@
+using Homassy.API.Context;
+using Homassy.API.Enums;
+using Homassy.Notifications.Services;
+using Microsoft.EntityFrameworkCore;
+using Serilog;
+
+namespace Homassy.Notifications.Workers;
+
+/// <summary>
+/// Background service that monitors family product inventory (készlet) for changes and notifies the
+/// other family members. Inventory create/update/delete/consume activities are accumulated into an
+/// in-memory session per family; once no further inventory activity occurs for the session timeout,
+/// one notification per non-zero action type (created / updated / deleted / consumed) is sent to all
+/// family members who did NOT contribute to that session, each carrying the count.
+///
+/// Inventory has no "list" container, so sessions are keyed by FamilyId. Notifications are count-only
+/// (no product names). Families with no eligible recipient (e.g. single-member families) receive
+/// nothing. Sessions are held purely in memory and cleared after notifications are dispatched.
+/// </summary>
+public sealed class InventoryActivityMonitorService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly FamilyPushNotifier _notifier;
+    private readonly TimeSpan _interval = TimeSpan.FromMinutes(5);
+    private readonly TimeSpan _sessionTimeout = TimeSpan.FromMinutes(5);
+
+    private static readonly ActivityType[] TrackedInventoryActivities =
+    {
+        ActivityType.ProductInventoryCreate,
+        ActivityType.ProductInventoryUpdate,
+        ActivityType.ProductInventoryDelete,
+        ActivityType.ProductInventoryDecrease
+    };
+
+    // Key: FamilyId
+    private readonly Dictionary<int, InventorySession> _activeSessions = new();
+    private DateTime _lastRun;
+
+    public InventoryActivityMonitorService(IServiceScopeFactory scopeFactory, FamilyPushNotifier notifier)
+    {
+        _scopeFactory = scopeFactory;
+        _notifier = notifier;
+        _lastRun = DateTime.UtcNow;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        Log.Information("Inventory activity monitor service started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(_interval, stoppingToken);
+                await ProcessAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error in inventory activity monitor service");
+                try { await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken); }
+                catch (OperationCanceledException) { break; }
+            }
+        }
+
+        Log.Information("Inventory activity monitor service stopped");
+    }
+
+    private async Task ProcessAsync(CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        var since = _lastRun;
+        _lastRun = now;
+
+        using var scope = _scopeFactory.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<HomassyDbContext>();
+
+        var activityData = await context.Activities
+            .Where(a => TrackedInventoryActivities.Contains(a.ActivityType)
+                && a.FamilyId != null
+                && a.Timestamp >= since
+                && a.Timestamp < now)
+            .Select(a => new { a.UserId, FamilyId = a.FamilyId!.Value, a.Timestamp, a.ActivityType })
+            .ToListAsync(cancellationToken);
+
+        foreach (var activity in activityData)
+        {
+            if (!_activeSessions.TryGetValue(activity.FamilyId, out var session))
+            {
+                session = new InventorySession
+                {
+                    FamilyId = activity.FamilyId,
+                    LastActivityAt = activity.Timestamp
+                };
+                _activeSessions[activity.FamilyId] = session;
+            }
+
+            session.Record(activity.ActivityType, activity.Timestamp, activity.UserId);
+        }
+
+        // Find sessions with no new activity for >= sessionTimeout and notify.
+        var staleSessions = _activeSessions.Values
+            .Where(s => s.LastActivityAt < now - _sessionTimeout)
+            .ToList();
+
+        foreach (var session in staleSessions)
+        {
+            try
+            {
+                await SendSessionNotificationsAsync(context, session, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error sending inventory notifications for family {FamilyId}", session.FamilyId);
+            }
+            finally
+            {
+                _activeSessions.Remove(session.FamilyId);
+            }
+        }
+
+        if (staleSessions.Count > 0 || activityData.Count > 0)
+        {
+            Log.Information(
+                "Inventory monitor: {NewActivities} new activities processed, {Stale} sessions notified, {Active} active sessions remaining",
+                activityData.Count, staleSessions.Count, _activeSessions.Count);
+        }
+    }
+
+    private async Task SendSessionNotificationsAsync(
+        HomassyDbContext context,
+        InventorySession session,
+        CancellationToken cancellationToken)
+    {
+        var recipients = await _notifier.GetRecipientsAsync(context, session.FamilyId, session.ContributingUserIds, cancellationToken);
+
+        if (recipients.Count == 0)
+        {
+            Log.Information(
+                "Inventory session closed – no eligible recipients (family {FamilyId})",
+                session.FamilyId);
+            return;
+        }
+
+        await _notifier.DispatchAsync(context, recipients,
+            language => BuildInventoryNotifications(session, language),
+            "/products", cancellationToken);
+
+        Log.Information(
+            "Inventory notifications sent to {Count} users (created {Created}, updated {Updated}, deleted {Deleted}, consumed {Consumed}, family {FamilyId})",
+            recipients.Count,
+            session.CreatedCount, session.UpdatedCount, session.DeletedCount, session.ConsumedCount,
+            session.FamilyId);
+    }
+
+    private static IReadOnlyList<(string Title, string Body)> BuildInventoryNotifications(
+        InventorySession session, Language language)
+    {
+        var notifications = new List<(string Title, string Body)>(4);
+
+        if (session.CreatedCount > 0)
+            notifications.Add(PushNotificationContentService.GetInventoryItemsCreatedContent(language, session.CreatedCount));
+
+        if (session.UpdatedCount > 0)
+            notifications.Add(PushNotificationContentService.GetInventoryItemsUpdatedContent(language, session.UpdatedCount));
+
+        if (session.DeletedCount > 0)
+            notifications.Add(PushNotificationContentService.GetInventoryItemsDeletedContent(language, session.DeletedCount));
+
+        if (session.ConsumedCount > 0)
+            notifications.Add(PushNotificationContentService.GetInventoryItemsConsumedContent(language, session.ConsumedCount));
+
+        return notifications;
+    }
+}
+
+internal sealed class InventorySession
+{
+    public int FamilyId { get; init; }
+    public DateTime LastActivityAt { get; set; }
+    public HashSet<int> ContributingUserIds { get; } = new();
+    public int CreatedCount { get; private set; }
+    public int UpdatedCount { get; private set; }
+    public int DeletedCount { get; private set; }
+    public int ConsumedCount { get; private set; }
+
+    public void Record(ActivityType activityType, DateTime timestamp, int userId)
+    {
+        ContributingUserIds.Add(userId);
+
+        if (timestamp > LastActivityAt)
+            LastActivityAt = timestamp;
+
+        switch (activityType)
+        {
+            case ActivityType.ProductInventoryCreate:
+                CreatedCount++;
+                break;
+            case ActivityType.ProductInventoryUpdate:
+                UpdatedCount++;
+                break;
+            case ActivityType.ProductInventoryDelete:
+                DeletedCount++;
+                break;
+            case ActivityType.ProductInventoryDecrease:
+                ConsumedCount++;
+                break;
+        }
+    }
+}

--- a/Homassy.Notifications/Workers/ShoppingListActivityMonitorService.cs
+++ b/Homassy.Notifications/Workers/ShoppingListActivityMonitorService.cs
@@ -1,4 +1,4 @@
-﻿using Homassy.API.Context;
+using Homassy.API.Context;
 using Homassy.API.Enums;
 using Homassy.Notifications.Services;
 using Microsoft.EntityFrameworkCore;
@@ -7,28 +7,44 @@ using Serilog;
 namespace Homassy.Notifications.Workers;
 
 /// <summary>
-/// Background service that monitors family shopping lists for new item additions.
-/// Every 5 minutes it checks for new ShoppingListItemAdd activities on family lists
-/// (where the family has at least 2 members). When no new items have been added
-/// for 5 minutes after an active session, it notifies all family members who did NOT
-/// contribute to that session. Sessions are held purely in memory and cleared after
-/// notifications are dispatched.
+/// Background service that monitors family shopping lists for changes and notifies family members.
+///
+/// Two kinds of notifications are produced:
+/// <list type="bullet">
+/// <item>Immediate, per-event notifications when a family shopping list is created or deleted.</item>
+/// <item>Aggregated, per-action session summaries for item changes. Item add/edit/delete/purchase
+/// activities on a list are accumulated into an in-memory session; once no further activity occurs
+/// for the session timeout, one notification per non-zero action type (added / edited / deleted /
+/// purchased) is sent to all family members who did NOT contribute to that session, each carrying
+/// the count.</item>
+/// </list>
+/// Only families with at least two active members are notified. Sessions are held purely in memory
+/// and cleared after notifications are dispatched.
 /// </summary>
 public sealed class ShoppingListActivityMonitorService : BackgroundService
 {
     private readonly IServiceScopeFactory _scopeFactory;
-    private readonly IWebPushService _webPushService;
+    private readonly FamilyPushNotifier _notifier;
     private readonly TimeSpan _interval = TimeSpan.FromMinutes(5);
     private readonly TimeSpan _sessionTimeout = TimeSpan.FromMinutes(5);
+
+    private static readonly ActivityType[] TrackedItemActivities =
+    {
+        ActivityType.ShoppingListItemAdd,
+        ActivityType.ShoppingListItemUpdate,
+        ActivityType.ShoppingListItemDelete,
+        ActivityType.ShoppingListItemPurchase,
+        ActivityType.ShoppingListItemQuickPurchase
+    };
 
     // Key: ShoppingListId
     private readonly Dictionary<int, ShoppingListSession> _activeSessions = new();
     private DateTime _lastRun;
 
-    public ShoppingListActivityMonitorService(IServiceScopeFactory scopeFactory, IWebPushService webPushService)
+    public ShoppingListActivityMonitorService(IServiceScopeFactory scopeFactory, FamilyPushNotifier notifier)
     {
         _scopeFactory = scopeFactory;
-        _webPushService = webPushService;
+        _notifier = notifier;
         _lastRun = DateTime.UtcNow;
     }
 
@@ -67,32 +83,87 @@ public sealed class ShoppingListActivityMonitorService : BackgroundService
         using var scope = _scopeFactory.CreateScope();
         var context = scope.ServiceProvider.GetRequiredService<HomassyDbContext>();
 
-        // Step 1: Load new ShoppingListItemAdd activities since the last run
-        var activityData = await context.Activities
-            .Where(a => a.ActivityType == ActivityType.ShoppingListItemAdd
+        await ProcessListEventsAsync(context, since, now, cancellationToken);
+        await ProcessItemActivitiesAsync(context, since, now, cancellationToken);
+    }
+
+    /// <summary>
+    /// Sends an immediate notification for each shopping list created/deleted since the last run.
+    /// The activity row already carries the family id and the list name, so no list lookup is needed
+    /// (this also works for lists that have since been deleted).
+    /// </summary>
+    private async Task ProcessListEventsAsync(HomassyDbContext context, DateTime since, DateTime now, CancellationToken cancellationToken)
+    {
+        var listEvents = await context.Activities
+            .Where(a => (a.ActivityType == ActivityType.ShoppingListCreate || a.ActivityType == ActivityType.ShoppingListDelete)
                 && a.FamilyId != null
                 && a.Timestamp >= since
                 && a.Timestamp < now)
-            .Select(a => new { a.UserId, a.FamilyId, a.Timestamp, ItemId = a.RecordId })
+            .Select(a => new { a.UserId, FamilyId = a.FamilyId!.Value, a.ActivityType, a.RecordName })
+            .ToListAsync(cancellationToken);
+
+        foreach (var ev in listEvents)
+        {
+            try
+            {
+                var recipients = await _notifier.GetRecipientsAsync(context, ev.FamilyId, new HashSet<int> { ev.UserId }, cancellationToken);
+                if (recipients.Count == 0)
+                    continue;
+
+                var created = ev.ActivityType == ActivityType.ShoppingListCreate;
+                await _notifier.DispatchAsync(context, recipients, language =>
+                {
+                    var content = created
+                        ? PushNotificationContentService.GetShoppingListCreatedContent(language, ev.RecordName)
+                        : PushNotificationContentService.GetShoppingListDeletedContent(language, ev.RecordName);
+                    return new[] { content };
+                }, "/shopping-lists", cancellationToken);
+
+                Log.Information(
+                    "Shopping list {EventType} notification sent to {Count} users for '{ListName}'",
+                    ev.ActivityType, recipients.Count, ev.RecordName);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error sending shopping list {EventType} notification for '{ListName}'", ev.ActivityType, ev.RecordName);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Accumulates item add/edit/delete/purchase activities into per-list sessions and dispatches
+    /// aggregated notifications once a session has been idle for at least <see cref="_sessionTimeout"/>.
+    /// </summary>
+    private async Task ProcessItemActivitiesAsync(HomassyDbContext context, DateTime since, DateTime now, CancellationToken cancellationToken)
+    {
+        var activityData = await context.Activities
+            .Where(a => TrackedItemActivities.Contains(a.ActivityType)
+                && a.FamilyId != null
+                && a.Timestamp >= since
+                && a.Timestamp < now)
+            .Select(a => new { a.UserId, a.Timestamp, ItemId = a.RecordId, a.ActivityType })
             .ToListAsync(cancellationToken);
 
         if (activityData.Count > 0)
         {
-            // Step 2: Resolve ShoppingListId for each activity (via ShoppingListItem)
+            // Resolve ShoppingListId for each activity (via ShoppingListItem).
+            // IgnoreQueryFilters so soft-deleted items (from delete activities) still resolve.
             var itemIds = activityData.Select(a => a.ItemId).Distinct().ToList();
             var itemToListId = await context.ShoppingListItems
+                .IgnoreQueryFilters()
                 .Where(sli => itemIds.Contains(sli.Id))
                 .Select(sli => new { sli.Id, sli.ShoppingListId })
                 .ToDictionaryAsync(sli => sli.Id, sli => sli.ShoppingListId, cancellationToken);
 
-            // Step 3: Load shopping list metadata for resolved list IDs
+            // Load shopping list metadata (including soft-deleted lists, so a just-deleted list can still be named).
             var listIds = itemToListId.Values.Distinct().ToList();
             var listInfo = await context.ShoppingLists
-                .Where(sl => listIds.Contains(sl.Id) && !sl.IsDeleted && sl.FamilyId != null)
+                .IgnoreQueryFilters()
+                .Where(sl => listIds.Contains(sl.Id) && sl.FamilyId != null)
                 .Select(sl => new { sl.Id, sl.Name, sl.FamilyId })
                 .ToDictionaryAsync(sl => sl.Id, sl => sl, cancellationToken);
 
-            // Step 4: Identify families with at least 2 active members
+            // Identify families with at least 2 active members.
             var familyIds = listInfo.Values.Select(sl => sl.FamilyId!.Value).Distinct().ToList();
             var eligibleFamilyIds = await context.Users
                 .Where(u => u.FamilyId != null && familyIds.Contains(u.FamilyId!.Value) && !u.IsDeleted)
@@ -103,7 +174,7 @@ public sealed class ShoppingListActivityMonitorService : BackgroundService
 
             var eligibleFamilySet = new HashSet<int>(eligibleFamilyIds);
 
-            // Step 5: Update in-memory sessions for eligible activities
+            // Update in-memory sessions for eligible activities.
             foreach (var activity in activityData)
             {
                 if (!itemToListId.TryGetValue(activity.ItemId, out var shoppingListId))
@@ -115,29 +186,23 @@ public sealed class ShoppingListActivityMonitorService : BackgroundService
                 if (!eligibleFamilySet.Contains(list.FamilyId!.Value))
                     continue;
 
-                if (_activeSessions.TryGetValue(shoppingListId, out var existing))
+                if (!_activeSessions.TryGetValue(shoppingListId, out var session))
                 {
-                    existing.ContributingUserIds.Add(activity.UserId);
-                    existing.NewItemCount++;
-                    if (activity.Timestamp > existing.LastActivityAt)
-                        existing.LastActivityAt = activity.Timestamp;
-                }
-                else
-                {
-                    _activeSessions[shoppingListId] = new ShoppingListSession
+                    session = new ShoppingListSession
                     {
                         ShoppingListId = shoppingListId,
                         FamilyId = list.FamilyId!.Value,
                         ShoppingListName = list.Name,
-                        LastActivityAt = activity.Timestamp,
-                        ContributingUserIds = new HashSet<int> { activity.UserId },
-                        NewItemCount = 1
+                        LastActivityAt = activity.Timestamp
                     };
+                    _activeSessions[shoppingListId] = session;
                 }
+
+                session.Record(activity.ActivityType, activity.Timestamp, activity.UserId);
             }
         }
 
-        // Step 6: Find sessions with no new activity for >= sessionTimeout and notify
+        // Find sessions with no new activity for >= sessionTimeout and notify.
         var staleSessions = _activeSessions.Values
             .Where(s => s.LastActivityAt < now - _sessionTimeout)
             .ToList();
@@ -146,7 +211,7 @@ public sealed class ShoppingListActivityMonitorService : BackgroundService
         {
             try
             {
-                await SendNotificationsAsync(context, session, cancellationToken);
+                await SendSessionNotificationsAsync(context, session, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -166,27 +231,12 @@ public sealed class ShoppingListActivityMonitorService : BackgroundService
         }
     }
 
-    private async Task SendNotificationsAsync(
+    private async Task SendSessionNotificationsAsync(
         HomassyDbContext context,
         ShoppingListSession session,
         CancellationToken cancellationToken)
     {
-        var contributingIds = session.ContributingUserIds;
-
-        var recipients = await context.Users
-            .AsNoTracking()
-            .Where(u => u.FamilyId == session.FamilyId
-                && !u.IsDeleted
-                && !contributingIds.Contains(u.Id)
-                && u.NotificationPreferences != null
-                && u.NotificationPreferences.PushNotificationsEnabled)
-            .Where(u => context.UserPushSubscriptions.Any(s => s.UserId == u.Id && !s.IsDeleted))
-            .Select(u => new
-            {
-                u.Id,
-                Language = u.Profile != null ? u.Profile.DefaultLanguage : Language.Hungarian
-            })
-            .ToListAsync(cancellationToken);
+        var recipients = await _notifier.GetRecipientsAsync(context, session.FamilyId, session.ContributingUserIds, cancellationToken);
 
         if (recipients.Count == 0)
         {
@@ -196,51 +246,40 @@ public sealed class ShoppingListActivityMonitorService : BackgroundService
             return;
         }
 
-        var hasChanges = false;
-
-        foreach (var recipient in recipients)
-        {
-            var subscriptions = await context.UserPushSubscriptions
-                .Where(s => s.UserId == recipient.Id && !s.IsDeleted)
-                .ToListAsync(cancellationToken);
-
-            var (title, body) = PushNotificationContentService.GetShoppingListActivityContent(
-                recipient.Language, session.ShoppingListName, session.NewItemCount);
-
-            var actionTitle = GetActionTitle(recipient.Language);
-
-            foreach (var subscription in subscriptions)
-            {
-                var success = await _webPushService.SendNotificationAsync(
-                    subscription, title, body, "/shopping-lists", actionTitle, cancellationToken);
-
-                if (!success)
-                {
-                    subscription.DeleteRecord();
-                    hasChanges = true;
-                    Log.Information(
-                        "Removed invalid push subscription {Endpoint} for user {UserId}",
-                        subscription.Endpoint, recipient.Id);
-                }
-            }
-        }
-
-        if (hasChanges)
-        {
-            await context.SaveChangesAsync(cancellationToken);
-        }
+        await _notifier.DispatchAsync(context, recipients,
+            language => BuildItemNotifications(session, language),
+            "/shopping-lists", cancellationToken);
 
         Log.Information(
-            "Shopping list '{ListName}' notification sent to {Count} users (list {ShoppingListId})",
-            session.ShoppingListName, recipients.Count, session.ShoppingListId);
+            "Shopping list '{ListName}' notifications sent to {Count} users (added {Added}, edited {Edited}, deleted {Deleted}, purchased {Purchased}, list {ShoppingListId})",
+            session.ShoppingListName, recipients.Count,
+            session.AddedCount, session.EditedCount, session.DeletedCount, session.PurchasedCount,
+            session.ShoppingListId);
     }
 
-    private static string GetActionTitle(Language language) => language switch
+    private static IReadOnlyList<(string Title, string Body)> BuildItemNotifications(
+        ShoppingListSession session, Language language)
     {
-        Language.German => "Homassy öffnen",
-        Language.English => "Open Homassy",
-        _ => "Homassy megnyitása"
-    };
+        var notifications = new List<(string Title, string Body)>(4);
+
+        if (session.AddedCount > 0)
+            notifications.Add(PushNotificationContentService.GetShoppingListItemsAddedContent(
+                language, session.ShoppingListName, session.AddedCount));
+
+        if (session.EditedCount > 0)
+            notifications.Add(PushNotificationContentService.GetShoppingListItemsEditedContent(
+                language, session.ShoppingListName, session.EditedCount));
+
+        if (session.DeletedCount > 0)
+            notifications.Add(PushNotificationContentService.GetShoppingListItemsDeletedContent(
+                language, session.ShoppingListName, session.DeletedCount));
+
+        if (session.PurchasedCount > 0)
+            notifications.Add(PushNotificationContentService.GetShoppingListItemsPurchasedContent(
+                language, session.ShoppingListName, session.PurchasedCount));
+
+        return notifications;
+    }
 }
 
 internal sealed class ShoppingListSession
@@ -249,6 +288,34 @@ internal sealed class ShoppingListSession
     public int FamilyId { get; init; }
     public string ShoppingListName { get; set; } = string.Empty;
     public DateTime LastActivityAt { get; set; }
-    public HashSet<int> ContributingUserIds { get; init; } = new();
-    public int NewItemCount { get; set; }
+    public HashSet<int> ContributingUserIds { get; } = new();
+    public int AddedCount { get; private set; }
+    public int EditedCount { get; private set; }
+    public int DeletedCount { get; private set; }
+    public int PurchasedCount { get; private set; }
+
+    public void Record(ActivityType activityType, DateTime timestamp, int userId)
+    {
+        ContributingUserIds.Add(userId);
+
+        if (timestamp > LastActivityAt)
+            LastActivityAt = timestamp;
+
+        switch (activityType)
+        {
+            case ActivityType.ShoppingListItemAdd:
+                AddedCount++;
+                break;
+            case ActivityType.ShoppingListItemUpdate:
+                EditedCount++;
+                break;
+            case ActivityType.ShoppingListItemDelete:
+                DeletedCount++;
+                break;
+            case ActivityType.ShoppingListItemPurchase:
+            case ActivityType.ShoppingListItemQuickPurchase:
+                PurchasedCount++;
+                break;
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Implements [#16](https://github.com/Xentinus/Homassy/issues/16) — expanded family push notifications so members stay informed about all relevant shared changes, batched and sent once editing goes idle (no per-event spam).

**Shopping lists** (`ShoppingListActivityMonitorService`)
- Immediate notifications when a family shopping list is **created** or **deleted**.
- Item sessions now track **add / edit / delete / purchase** (previously only add); `Purchase` + `QuickPurchase` count as purchased.
- On session idle, sends **one notification per non-zero action type** to family members who did not contribute. Soft-deleted items/lists still resolve via `IgnoreQueryFilters`.

**Inventory / készlet** (new `InventoryActivityMonitorService`)
- Tracks **create / update / delete / consume** (`ProductInventory*`) activities, aggregated per **family**.
- On idle, sends one count-only notification per non-zero action type to the other family members.

**Shared infrastructure**
- New `FamilyPushNotifier` service centralizes recipient resolution + push dispatch (with invalid-subscription cleanup); both monitors reuse it.
- New localized (HU/DE/EN) content methods in `PushNotificationContentService`.
- Registered `FamilyPushNotifier` and `InventoryActivityMonitorService` in `Program.cs`; updated service `CLAUDE.md`.

No client-side changes required — the existing push payload shape and service worker consume the notifications as-is.

Closes #16