### PR TITLE
feat(shopping-list): realtime updates via SignalR per-list channels

### DIFF
--- a/Homassy.API/Functions/ShoppingListFunctions.cs
+++ b/Homassy.API/Functions/ShoppingListFunctions.cs
@@ -2,6 +2,7 @@
 using Homassy.API.Entities.ShoppingList;
 using Homassy.API.Exceptions;
 using Homassy.API.Extensions;
+using Homassy.API.Hubs;
 using Homassy.API.Models.Common;
 using Homassy.API.Models.ShoppingList;
 using Microsoft.EntityFrameworkCore;
@@ -400,8 +401,6 @@ namespace Homassy.API.Functions
             }
 
             var items = GetShoppingListItemsByShoppingListId(shoppingList.Id, showPurchased);
-            var locationFunctions = new LocationFunctions();
-            var productFunctions = new ProductFunctions();
 
             return new DetailedShoppingListInfo
             {
@@ -410,28 +409,40 @@ namespace Homassy.API.Functions
                 Description = shoppingList.Description,
                 Color = shoppingList.Color,
                 IsSharedWithFamily = shoppingList.FamilyId.HasValue,
-                Items = items.Select(sli =>
-                {
-                    var product = sli.ProductId.HasValue ? productFunctions.GetProductById(sli.ProductId) : null;
-                    var shoppingLocation = sli.ShoppingLocationId.HasValue ? locationFunctions.GetShoppingLocationById(sli.ShoppingLocationId) : null;
+                Items = items.Select(sli => BuildItemInfo(sli, shoppingList)).ToList()
+            };
+        }
 
-                    return new ShoppingListItemInfo
-                    {
-                        PublicId = sli.PublicId,
-                        ShoppingListPublicId = shoppingList.PublicId,
-                        ProductPublicId = product?.PublicId,
-                        ShoppingLocationPublicId = shoppingLocation?.PublicId,
-                        Product = productFunctions.ConvertToProductInfo(product, userId),
-                        ShoppingLocation = locationFunctions.ConvertToShoppingLocationInfo(shoppingLocation),
-                        CustomName = sli.CustomName,
-                        Quantity = sli.Quantity,
-                        Unit = sli.Unit,
-                        Note = sli.Note,
-                        PurchasedAt = sli.PurchasedAt,
-                        DeadlineAt = sli.DeadlineAt,
-                        DueAt = sli.DueAt
-                    };
-                }).ToList()
+        /// <summary>
+        /// Builds a fully-hydrated <see cref="ShoppingListItemInfo"/> (with nested product and
+        /// shopping-location details) for a shopping list item. Used both for the list snapshot
+        /// and for realtime broadcasts, so receivers can render an item without an extra fetch.
+        /// The product's per-user fields (e.g. favorite) reflect the current <see cref="SessionInfo"/>.
+        /// </summary>
+        public ShoppingListItemInfo BuildItemInfo(ShoppingListItem item, ShoppingList list)
+        {
+            var productFunctions = new ProductFunctions();
+            var locationFunctions = new LocationFunctions();
+            var userId = SessionInfo.GetUserId();
+
+            var product = item.ProductId.HasValue ? productFunctions.GetProductById(item.ProductId) : null;
+            var shoppingLocation = item.ShoppingLocationId.HasValue ? locationFunctions.GetShoppingLocationById(item.ShoppingLocationId) : null;
+
+            return new ShoppingListItemInfo
+            {
+                PublicId = item.PublicId,
+                ShoppingListPublicId = list.PublicId,
+                ProductPublicId = product?.PublicId,
+                ShoppingLocationPublicId = shoppingLocation?.PublicId,
+                Product = productFunctions.ConvertToProductInfo(product, userId),
+                ShoppingLocation = locationFunctions.ConvertToShoppingLocationInfo(shoppingLocation),
+                CustomName = item.CustomName,
+                Quantity = item.Quantity,
+                Unit = item.Unit,
+                Note = item.Note,
+                PurchasedAt = item.PurchasedAt,
+                DeadlineAt = item.DeadlineAt,
+                DueAt = item.DueAt
             };
         }
 
@@ -603,6 +614,16 @@ namespace Homassy.API.Functions
                     {
                         Log.Error(ex, $"Failed to record ShoppingListUpdate activity for shopping list {trackedList.Name}");
                     }
+
+                    // Notify everyone viewing this list of the metadata change.
+                    await ShoppingListRealtime.ListUpdatedAsync(new ShoppingListInfo
+                    {
+                        PublicId = trackedList.PublicId,
+                        Name = trackedList.Name,
+                        Description = trackedList.Description,
+                        Color = trackedList.Color,
+                        IsSharedWithFamily = trackedList.FamilyId.HasValue
+                    }, cancellationToken);
                 }
 
                 return new ShoppingListInfo
@@ -691,6 +712,9 @@ namespace Homassy.API.Functions
                 {
                     Log.Error(ex, $"Failed to record ShoppingListDelete activity for shopping list {shoppingList.Name}");
                 }
+
+                // Notify everyone viewing this list that it was deleted.
+                await ShoppingListRealtime.ListDeletedAsync(shoppingList.PublicId, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -805,6 +829,9 @@ namespace Homassy.API.Functions
                 {
                     Log.Error(ex, $"Failed to record ShoppingListItemAdd activity for shopping list item {shoppingListItem.PublicId}");
                 }
+
+                // Notify everyone viewing this list of the new item.
+                await ShoppingListRealtime.ItemUpsertedAsync(shoppingList.PublicId, BuildItemInfo(shoppingListItem, shoppingList), cancellationToken);
 
                 return new ShoppingListItemInfo
                 {
@@ -978,6 +1005,9 @@ namespace Homassy.API.Functions
                     {
                         Log.Error(ex, $"Failed to record ShoppingListItemUpdate activity for shopping list item {trackedItem.PublicId}");
                     }
+
+                    // Notify everyone viewing this list of the change.
+                    await ShoppingListRealtime.ItemUpsertedAsync(shoppingList.PublicId, BuildItemInfo(trackedItem, shoppingList), cancellationToken);
                 }
 
                 return new ShoppingListItemInfo
@@ -1074,6 +1104,9 @@ namespace Homassy.API.Functions
                 {
                     Log.Error(ex, $"Failed to record ShoppingListItemDelete activity for shopping list item {shoppingListItem.PublicId}");
                 }
+
+                // Notify everyone viewing this list that the item was removed.
+                await ShoppingListRealtime.ItemDeletedAsync(shoppingList.PublicId, shoppingListItem.PublicId, cancellationToken);
             }
             catch (Exception ex)
             {
@@ -1166,6 +1199,8 @@ namespace Homassy.API.Functions
                         DeadlineAt = trackedShoppingListItem.DeadlineAt,
                         DueAt = trackedShoppingListItem.DueAt
                     };
+
+                    await ShoppingListRealtime.ItemUpsertedAsync(shoppingList.PublicId, BuildItemInfo(trackedShoppingListItem, shoppingList), cancellationToken);
 
                     return customItemInfo;
                 }
@@ -1270,6 +1305,8 @@ namespace Homassy.API.Functions
                     DueAt = trackedShoppingListItem.DueAt
                 };
 
+                await ShoppingListRealtime.ItemUpsertedAsync(shoppingList.PublicId, BuildItemInfo(trackedShoppingListItem, shoppingList), cancellationToken);
+
                 return shoppingListItemInfo;
             }
             catch (Exception ex)
@@ -1370,6 +1407,8 @@ namespace Homassy.API.Functions
                     DueAt = trackedShoppingListItem.DueAt
                 };
 
+                await ShoppingListRealtime.ItemUpsertedAsync(shoppingList.PublicId, BuildItemInfo(trackedShoppingListItem, shoppingList), cancellationToken);
+
                 return shoppingListItemInfo;
             }
             catch (Exception ex)
@@ -1469,6 +1508,8 @@ namespace Homassy.API.Functions
                     DeadlineAt = trackedShoppingListItem.DeadlineAt,
                     DueAt = trackedShoppingListItem.DueAt
                 };
+
+                await ShoppingListRealtime.ItemUpsertedAsync(shoppingList.PublicId, BuildItemInfo(trackedShoppingListItem, shoppingList), cancellationToken);
 
                 return shoppingListItemInfo;
             }
@@ -1604,6 +1645,12 @@ namespace Homassy.API.Functions
                     }
                 }
 
+                // Notify everyone viewing this list of each new item.
+                foreach (var sli in createdItems)
+                {
+                    await ShoppingListRealtime.ItemUpsertedAsync(shoppingList.PublicId, BuildItemInfo(sli, shoppingList), cancellationToken);
+                }
+
                 return createdItems.Select(sli => new ShoppingListItemInfo
                 {
                     PublicId = sli.PublicId,
@@ -1643,6 +1690,7 @@ namespace Homassy.API.Functions
 
             var familyId = SessionInfo.GetFamilyId();
             var productFunctions = new ProductFunctions();
+            var deletedItems = new List<(Guid listPublicId, Guid itemPublicId)>();
 
             var context = new HomassyDbContext();
             await using var transaction = await context.Database.BeginTransactionAsync(cancellationToken);
@@ -1679,6 +1727,7 @@ namespace Homassy.API.Functions
 
                     trackedItem.DeleteRecord(userId.Value);
                     context.ShoppingListItems.Update(trackedItem);
+                    deletedItems.Add((shoppingList.PublicId, shoppingListItem.PublicId));
 
                     // Record activity for each deleted item
                     try
@@ -1706,6 +1755,12 @@ namespace Homassy.API.Functions
                 await transaction.CommitAsync(cancellationToken);
 
                 Log.Information($"User {userId.Value} deleted {request.ItemPublicIds.Count} shopping list items");
+
+                // Notify everyone viewing the affected list(s) that the items were removed.
+                foreach (var (listPublicId, itemPublicId) in deletedItems)
+                {
+                    await ShoppingListRealtime.ItemDeletedAsync(listPublicId, itemPublicId, cancellationToken);
+                }
             }
             catch (Exception ex)
             {
@@ -1741,6 +1796,7 @@ namespace Homassy.API.Functions
             {
                 var results = new List<ShoppingListItemInfo>();
                 var affectedProductIds = new HashSet<int>();
+                var upsertedItems = new List<(ShoppingList list, ShoppingListItem item)>();
 
                 foreach (var itemRequest in request.Items)
                 {
@@ -1859,6 +1915,8 @@ namespace Homassy.API.Functions
                         DeadlineAt = trackedShoppingListItem.DeadlineAt,
                         DueAt = trackedShoppingListItem.DueAt
                     });
+
+                    upsertedItems.Add((shoppingList, trackedShoppingListItem));
                 }
 
                 await context.SaveChangesAsync(cancellationToken);
@@ -1869,6 +1927,12 @@ namespace Homassy.API.Functions
                     await AutomationFunctions.CheckLowStockForProductAsync(pid, cancellationToken);
 
                 Log.Information($"User {userId.Value} quick purchased {results.Count} shopping list items");
+
+                // Notify everyone viewing the affected list(s) of each purchased item.
+                foreach (var (list, item) in upsertedItems)
+                {
+                    await ShoppingListRealtime.ItemUpsertedAsync(list.PublicId, BuildItemInfo(item, list), cancellationToken);
+                }
 
                 return results;
             }

--- a/Homassy.API/Hubs/ShoppingListHub.cs
+++ b/Homassy.API/Hubs/ShoppingListHub.cs
@@ -1,0 +1,95 @@
+using Homassy.API.Context;
+using Homassy.API.Functions;
+using Homassy.API.Middleware;
+using Homassy.API.Models.Kratos;
+using Homassy.API.Models.ShoppingList;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using Serilog;
+
+namespace Homassy.API.Hubs
+{
+    /// <summary>
+    /// Realtime channel for shopping lists. Each shopping list is a SignalR group
+    /// (<see cref="ShoppingListRealtime.GroupName"/>); a client joins the group of the list it is
+    /// viewing and receives live <c>ItemUpserted</c> / <c>ItemDeleted</c> / <c>ListUpdated</c> /
+    /// <c>ListDeleted</c> events for it.
+    ///
+    /// Authentication reuses the existing pipeline: the Kratos session cookie rides the WebSocket
+    /// handshake, <see cref="KratosSessionMiddleware"/> validates it and sets the principal, so
+    /// <see cref="AuthorizeAttribute"/> works exactly as on the controllers. The validated
+    /// <see cref="KratosSession"/> is captured at connect and replayed into <see cref="SessionInfo"/>
+    /// around each invocation so the existing <see cref="ShoppingListFunctions"/> (which read
+    /// <see cref="SessionInfo"/>) can be reused unchanged for access checks.
+    /// </summary>
+    [Authorize]
+    public class ShoppingListHub : Hub
+    {
+        private const string SessionItemKey = "KratosSession";
+
+        public override async Task OnConnectedAsync()
+        {
+            // KratosSessionMiddleware ran during the handshake and stashed the session on the
+            // HttpContext; capture it for the lifetime of this connection.
+            var session = Context.GetHttpContext()?.GetKratosSession();
+            if (session != null)
+            {
+                Context.Items[SessionItemKey] = session;
+            }
+
+            await base.OnConnectedAsync();
+        }
+
+        /// <summary>
+        /// Joins the caller to a shopping list's channel and returns its current items.
+        /// The snapshot is produced by the same access-checked path used by the REST endpoint,
+        /// so unauthorized lists are rejected and no separate fetch is needed after joining.
+        /// </summary>
+        public async Task<DetailedShoppingListInfo> JoinList(Guid publicId, bool showPurchased = false)
+        {
+            var session = GetSession();
+
+            DetailedShoppingListInfo? snapshot;
+            try
+            {
+                SessionInfo.SetFromKratosSession(session);
+                snapshot = new ShoppingListFunctions().GetDetailedShoppingList(publicId, showPurchased);
+            }
+            catch (Exceptions.ShoppingListAccessDeniedException)
+            {
+                throw new HubException("Access to this shopping list was denied.");
+            }
+            finally
+            {
+                SessionInfo.Clear();
+            }
+
+            if (snapshot == null)
+            {
+                throw new HubException("Shopping list not found.");
+            }
+
+            await Groups.AddToGroupAsync(Context.ConnectionId, ShoppingListRealtime.GroupName(publicId));
+            Log.Debug("Connection {ConnectionId} joined shopping list {PublicId}", Context.ConnectionId, publicId);
+
+            return snapshot;
+        }
+
+        /// <summary>Removes the caller from a shopping list's channel (e.g. when switching lists).</summary>
+        public async Task LeaveList(Guid publicId)
+        {
+            await Groups.RemoveFromGroupAsync(Context.ConnectionId, ShoppingListRealtime.GroupName(publicId));
+            Log.Debug("Connection {ConnectionId} left shopping list {PublicId}", Context.ConnectionId, publicId);
+        }
+
+        private KratosSession GetSession()
+        {
+            if (Context.Items.TryGetValue(SessionItemKey, out var stored) && stored is KratosSession session)
+            {
+                return session;
+            }
+
+            throw new HubException("Unauthorized.");
+        }
+    }
+}

--- a/Homassy.API/Hubs/ShoppingListRealtime.cs
+++ b/Homassy.API/Hubs/ShoppingListRealtime.cs
@@ -1,0 +1,67 @@
+using Homassy.API.Infrastructure;
+using Homassy.API.Models.ShoppingList;
+using Microsoft.AspNetCore.SignalR;
+using Serilog;
+
+namespace Homassy.API.Hubs
+{
+    /// <summary>
+    /// Broadcast helper for pushing shopping list changes to connected clients over SignalR.
+    /// Writes still flow through the REST endpoints / <see cref="Functions.ShoppingListFunctions"/>;
+    /// after a successful commit the Functions layer calls into here to notify everyone viewing
+    /// the affected list. Resolves the hub context from the application <see cref="ServiceLocator"/>
+    /// (the Functions layer is instantiated with <c>new</c>, so constructor injection isn't available),
+    /// mirroring the existing static cross-cutting pattern used elsewhere in the codebase.
+    /// </summary>
+    public static class ShoppingListRealtime
+    {
+        public const string ItemUpsertedEvent = "ItemUpserted";
+        public const string ItemDeletedEvent = "ItemDeleted";
+        public const string ListUpdatedEvent = "ListUpdated";
+        public const string ListDeletedEvent = "ListDeleted";
+
+        /// <summary>
+        /// SignalR group name for a single shopping list. Shared with <see cref="ShoppingListHub"/>.
+        /// </summary>
+        public static string GroupName(Guid listPublicId) => $"shopping-list:{listPublicId}";
+
+        private static IHubContext<ShoppingListHub>? HubContext =>
+            ServiceLocator.Provider?.GetService<IHubContext<ShoppingListHub>>();
+
+        /// <summary>Pushes the current (hydrated) state of an item to the list's group (covers create/update/purchase/restore).</summary>
+        public static Task ItemUpsertedAsync(Guid listPublicId, ShoppingListItemInfo item, CancellationToken cancellationToken = default)
+            => SendAsync(listPublicId, ItemUpsertedEvent, item, cancellationToken);
+
+        /// <summary>Notifies the list's group that an item was removed.</summary>
+        public static Task ItemDeletedAsync(Guid listPublicId, Guid itemPublicId, CancellationToken cancellationToken = default)
+            => SendAsync(listPublicId, ItemDeletedEvent, new { publicId = itemPublicId, shoppingListPublicId = listPublicId }, cancellationToken);
+
+        /// <summary>Notifies the list's group that list metadata (name, color, sharing) changed.</summary>
+        public static Task ListUpdatedAsync(ShoppingListInfo list, CancellationToken cancellationToken = default)
+            => SendAsync(list.PublicId, ListUpdatedEvent, list, cancellationToken);
+
+        /// <summary>Notifies the list's group that the list itself was deleted.</summary>
+        public static Task ListDeletedAsync(Guid listPublicId, CancellationToken cancellationToken = default)
+            => SendAsync(listPublicId, ListDeletedEvent, new { publicId = listPublicId }, cancellationToken);
+
+        private static async Task SendAsync(Guid listPublicId, string eventName, object payload, CancellationToken cancellationToken)
+        {
+            var hub = HubContext;
+            if (hub == null)
+            {
+                Log.Warning("ShoppingListHub context unavailable; skipping {Event} broadcast for list {ListPublicId}", eventName, listPublicId);
+                return;
+            }
+
+            try
+            {
+                await hub.Clients.Group(GroupName(listPublicId)).SendAsync(eventName, payload, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                // A broadcast failure must never break the HTTP write that triggered it.
+                Log.Error(ex, "Failed to broadcast {Event} for shopping list {ListPublicId}", eventName, listPublicId);
+            }
+        }
+    }
+}

--- a/Homassy.API/Program.cs
+++ b/Homassy.API/Program.cs
@@ -2,6 +2,7 @@
 using Homassy.API.Extensions;
 using Homassy.API.Functions;
 using Homassy.API.HealthChecks;
+using Homassy.API.Hubs;
 using Homassy.API.Infrastructure;
 using Homassy.API.Middleware;
 using Homassy.API.Models.ApplicationSettings;
@@ -19,6 +20,7 @@ using System.IO.Compression;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text;
+using System.Text.Json;
 
 Log.Logger = new LoggerConfiguration()
     .MinimumLevel.Debug()
@@ -169,6 +171,14 @@ try
         {
             options.JsonSerializerOptions.PropertyNameCaseInsensitive = true;
         });
+
+    // SignalR realtime hub for shopping lists. camelCase payloads match the MVC JSON
+    // output and the frontend TypeScript types (publicId, shoppingListPublicId, ...).
+    builder.Services.AddSignalR()
+        .AddJsonProtocol(options =>
+        {
+            options.PayloadSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
+        });
     builder.Services.AddOpenApi(options =>
     {
         options.AddDocumentTransformer((document, context, cancellationToken) =>
@@ -291,6 +301,10 @@ try
     app.UseAuthorization();
     app.UseMiddleware<SessionInfoMiddleware>();
     app.MapControllers();
+
+    // Realtime shopping list channel. Auth flows through KratosSessionMiddleware (above) just
+    // like the controllers; RequireCors is explicit because credentialed WS negotiation is strict.
+    app.MapHub<ShoppingListHub>("/hubs/shopping-list").RequireCors("HomassyPolicy");
 
     Log.Information("Homassy API started successfully");
 

--- a/Homassy.Web/app/composables/useShoppingListSocket.ts
+++ b/Homassy.Web/app/composables/useShoppingListSocket.ts
@@ -1,0 +1,142 @@
+/**
+ * Shopping list realtime socket (SignalR).
+ *
+ * Manages a single app-wide connection to the API's `/hubs/shopping-list` hub. A client
+ * "joins" the list it is viewing and receives live `ItemUpserted` / `ItemDeleted` /
+ * `ListUpdated` / `ListDeleted` events for it, so the open list stays current without
+ * polling or manual refresh. Writes still go through the REST endpoints; the server
+ * broadcasts the resulting change to everyone in the list's group.
+ *
+ * Auth: the Kratos session cookie is sent on the WS handshake via `withCredentials`, so the
+ * existing server-side session middleware authenticates the connection — no token plumbing.
+ *
+ * Everything is guarded by `isSupported` (client-only); on the server the methods are no-ops
+ * and `joinList` returns `null` so callers can fall back to a plain REST fetch.
+ */
+import * as signalR from '@microsoft/signalr'
+import { ref } from 'vue'
+import type { DetailedShoppingListInfo } from '~/types/shoppingList'
+
+// Module-level singletons: one connection shared across the whole app.
+let connection: signalR.HubConnection | null = null
+let startPromise: Promise<void> | null = null
+const isConnected = ref(false)
+
+// Track what we're currently joined to, so we can re-join after an automatic reconnect
+// (SignalR groups are connection-scoped and are lost when the connection is rebuilt).
+let currentListId: string | null = null
+let currentShowPurchased = false
+const reconnectedCallbacks: Array<() => void> = []
+
+export const useShoppingListSocket = () => {
+  const isSupported = import.meta.client
+  const config = useRuntimeConfig()
+  const apiBase = (config.public.apiBase as string) || 'http://localhost:5226'
+
+  const getConnection = (): signalR.HubConnection | null => {
+    if (!isSupported) return null
+
+    if (!connection) {
+      const url = `${apiBase.replace(/\/$/, '')}/hubs/shopping-list`
+
+      connection = new signalR.HubConnectionBuilder()
+        .withUrl(url, { withCredentials: true })
+        .withAutomaticReconnect()
+        .configureLogging(signalR.LogLevel.Warning)
+        .build()
+
+      connection.onreconnecting(() => { isConnected.value = false })
+      connection.onclose(() => { isConnected.value = false })
+      connection.onreconnected(() => {
+        isConnected.value = true
+        // Re-sync: let consumers reload the snapshot (which re-joins the group). If no
+        // consumer registered, best-effort re-join so we keep receiving events.
+        if (reconnectedCallbacks.length > 0) {
+          reconnectedCallbacks.forEach((cb) => { try { cb() } catch { /* ignore */ } })
+        } else if (currentListId) {
+          connection?.invoke('JoinList', currentListId, currentShowPurchased).catch(() => { /* ignore */ })
+        }
+      })
+    }
+
+    return connection
+  }
+
+  const ensureConnected = async (): Promise<signalR.HubConnection | null> => {
+    const conn = getConnection()
+    if (!conn) return null
+
+    if (conn.state === signalR.HubConnectionState.Connected) return conn
+
+    if (!startPromise) {
+      startPromise = conn.start()
+        .then(() => { isConnected.value = true })
+        .catch((error) => { startPromise = null; throw error })
+    }
+
+    await startPromise
+    return conn
+  }
+
+  /**
+   * Joins a shopping list's channel and returns its current items (the snapshot).
+   * Returns `null` when sockets aren't available (SSR) so the caller can fetch via REST.
+   */
+  const joinList = async (publicId: string, showPurchased = false): Promise<DetailedShoppingListInfo | null> => {
+    if (!isSupported) return null
+
+    const conn = await ensureConnected()
+    if (!conn) return null
+
+    currentListId = publicId
+    currentShowPurchased = showPurchased
+
+    return await conn.invoke<DetailedShoppingListInfo>('JoinList', publicId, showPurchased)
+  }
+
+  /** Leaves a shopping list's channel (e.g. when switching lists). Safe to call anytime. */
+  const leaveList = async (publicId: string): Promise<void> => {
+    if (currentListId === publicId) currentListId = null
+
+    const conn = connection
+    if (!conn || conn.state !== signalR.HubConnectionState.Connected) return
+
+    try {
+      await conn.invoke('LeaveList', publicId)
+    } catch {
+      // Ignore — leaving is best-effort (the group is dropped on disconnect anyway).
+    }
+  }
+
+  /** Subscribe to a hub event (ItemUpserted / ItemDeleted / ListUpdated / ListDeleted). */
+  const on = (event: string, handler: (...args: any[]) => void): void => {
+    getConnection()?.on(event, handler)
+  }
+
+  /** Unsubscribe a previously registered handler. */
+  const off = (event: string, handler: (...args: any[]) => void): void => {
+    connection?.off(event, handler)
+  }
+
+  /** Register a callback to run after an automatic reconnect (to re-sync the open list). */
+  const onReconnected = (callback: () => void): void => {
+    if (!reconnectedCallbacks.includes(callback)) reconnectedCallbacks.push(callback)
+  }
+
+  const offReconnected = (callback: () => void): void => {
+    const index = reconnectedCallbacks.indexOf(callback)
+    if (index >= 0) reconnectedCallbacks.splice(index, 1)
+  }
+
+  return {
+    isSupported,
+    isConnected,
+    ensureConnected,
+    joinList,
+    leaveList,
+    on,
+    off,
+    onReconnected,
+    offReconnected
+  }
+}

--- a/Homassy.Web/app/pages/shopping-lists/index.vue
+++ b/Homassy.Web/app/pages/shopping-lists/index.vue
@@ -507,7 +507,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import type { SelectValue } from '../../types/selectValue'
-import type { DetailedShoppingListInfo, CreateShoppingListRequest, UpdateShoppingListRequest, ShoppingListItemInfo } from '../../types/shoppingList'
+import type { DetailedShoppingListInfo, CreateShoppingListRequest, UpdateShoppingListRequest, ShoppingListItemInfo, ShoppingListInfo } from '../../types/shoppingList'
 import { SelectValueType } from '../../types/enums'
 import { useSelectValueApi } from '../../composables/api/useSelectValueApi'
 import { useShoppingListApi } from '../../composables/api/useShoppingListApi'
@@ -524,6 +524,10 @@ const { getSelectValues } = useSelectValueApi()
 const { getShoppingListDetails, createShoppingList, updateShoppingList, deleteShoppingList } = useShoppingListApi()
 const { showCameraButton } = useCameraAvailability()
 const { isExpired: checkIsExpired, isExpiringWithinTwoWeeks: checkIsExpiringWithinTwoWeeks } = useExpirationCheck()
+
+// Realtime channel for the currently-open list (see useShoppingListSocket).
+const socket = useShoppingListSocket()
+const { emit: emitBusEvent } = useEventBus()
 
 const { pullDistance, isPulling, isRefreshing, isReady } = usePullToRefresh(async () => {
   await loadShoppingLists()
@@ -857,18 +861,29 @@ const loadShoppingLists = async () => {
   }
 }
 
+const fetchListDetailsRest = async (publicId: string) => {
+  const response = await getShoppingListDetails(publicId, showPurchased.value)
+  if (response.success && response.data) {
+    currentListDetails.value = response.data
+  }
+}
+
 const loadListDetails = async (publicId: string) => {
   isLoadingDetails.value = true
   searchQuery.value = '' // Reset search when switching lists
 
   try {
-    const response = await getShoppingListDetails(publicId)
-
-    if (response.success && response.data) {
-      currentListDetails.value = response.data
+    // Join the realtime channel; the hub returns the current snapshot, so no extra
+    // fetch is needed. Falls back to a plain REST fetch when sockets are unavailable.
+    const snapshot = await socket.joinList(publicId, showPurchased.value)
+    if (snapshot) {
+      currentListDetails.value = snapshot
+    } else {
+      await fetchListDetailsRest(publicId)
     }
   } catch (error) {
     console.error('Failed to load list details:', error)
+    try { await fetchListDetailsRest(publicId) } catch { /* already logged above */ }
   } finally {
     isLoadingDetails.value = false
   }
@@ -996,11 +1011,51 @@ const handleDeleteList = async () => {
   }
 }
 
-// Handle item refresh (when item is updated, deleted, purchased, or restored)
+// Handle item refresh (when item is updated, deleted, purchased, or restored).
+// The realtime channel keeps the open list in sync — including this client's own change,
+// echoed back from the server — so a manual refetch is only needed when the socket is down.
 const handleItemRefresh = async () => {
-  if (selectedListId.value) {
+  if (!socket.isConnected.value && selectedListId.value) {
     await loadListDetails(selectedListId.value)
   }
+}
+
+// --- Realtime handlers: mutate the open list in place instead of refetching. ---
+const handleRealtimeItemUpserted = (item: ShoppingListItemInfo) => {
+  if (!currentListDetails.value || item.shoppingListPublicId !== selectedListId.value) return
+  const items = currentListDetails.value.items
+  const index = items.findIndex(i => i.publicId === item.publicId)
+  if (index >= 0) items[index] = item
+  else items.push(item)
+  // Nudge the bottom-nav deadline badge to recount.
+  emitBusEvent('shopping-list-item:updated')
+}
+
+const handleRealtimeItemDeleted = (payload: { publicId: string; shoppingListPublicId: string }) => {
+  if (!currentListDetails.value || payload.shoppingListPublicId !== selectedListId.value) return
+  currentListDetails.value.items = currentListDetails.value.items.filter(i => i.publicId !== payload.publicId)
+  emitBusEvent('shopping-list-item:deleted')
+}
+
+const handleRealtimeListUpdated = (list: ShoppingListInfo) => {
+  if (!currentListDetails.value || list.publicId !== selectedListId.value) return
+  currentListDetails.value.name = list.name
+  currentListDetails.value.description = list.description
+  currentListDetails.value.color = list.color
+  currentListDetails.value.isSharedWithFamily = list.isSharedWithFamily
+}
+
+const handleRealtimeListDeleted = (payload: { publicId: string }) => {
+  if (payload.publicId !== selectedListId.value) return
+  // The open list was deleted by someone else — reset selection and refresh the selector.
+  currentListDetails.value = null
+  selectedListId.value = null
+  loadShoppingLists()
+}
+
+const handleSocketReconnected = () => {
+  // Re-sync the snapshot after a dropped connection (this also re-joins the group).
+  if (selectedListId.value) loadListDetails(selectedListId.value)
 }
 
 // Barcode scanner handler
@@ -1009,11 +1064,14 @@ const handleBarcodeScanned = (barcode: string) => {
 }
 
 // Watchers
-watch(selectedListId, (newId) => {
+watch(selectedListId, (newId, oldId) => {
   // Reset list-dependent filters when switching lists (options differ per list).
   locationFilter.value = 'all'
   minQuantity.value = null
   maxQuantity.value = null
+
+  // Leave the previous list's channel so we stop receiving its events.
+  if (oldId) socket.leaveList(oldId)
 
   if (newId) {
     loadListDetails(newId)
@@ -1043,6 +1101,13 @@ watch(showPurchased, (newValue) => {
 
 // Lifecycle
 onMounted(() => {
+  // Register realtime handlers before any list is joined so no events are missed.
+  socket.on('ItemUpserted', handleRealtimeItemUpserted)
+  socket.on('ItemDeleted', handleRealtimeItemDeleted)
+  socket.on('ListUpdated', handleRealtimeListUpdated)
+  socket.on('ListDeleted', handleRealtimeListDeleted)
+  socket.onReconnected(handleSocketReconnected)
+
   // Restore showPurchased state from localStorage
   const savedShowPurchased = localStorage.getItem(SHOW_PURCHASED_KEY)
   if (savedShowPurchased !== null) {
@@ -1073,6 +1138,15 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  // Tear down realtime subscriptions and leave the open list's channel (the shared
+  // connection itself stays alive for other pages / quick re-entry).
+  socket.off('ItemUpserted', handleRealtimeItemUpserted)
+  socket.off('ItemDeleted', handleRealtimeItemDeleted)
+  socket.off('ListUpdated', handleRealtimeListUpdated)
+  socket.off('ListDeleted', handleRealtimeListDeleted)
+  socket.offReconnected(handleSocketReconnected)
+  if (selectedListId.value) socket.leaveList(selectedListId.value)
+
   if (headerObserver) {
     headerObserver.disconnect()
     headerObserver = null

--- a/Homassy.Web/package-lock.json
+++ b/Homassy.Web/package-lock.json
@@ -10,6 +10,7 @@
         "@iconify-json/heroicons": "^1.2.3",
         "@iconify-json/lucide": "^1.2.82",
         "@internationalized/date": "^3.10.1",
+        "@microsoft/signalr": "^10.0.0",
         "@nuxt/content": "^3.9.0",
         "@nuxt/eslint": "^1.12.1",
         "@nuxt/hints": "^1.0.0-alpha.4",
@@ -99,6 +100,7 @@
     "node_modules/@babel/core": {
       "version": "7.28.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -418,6 +420,7 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
       "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.28.6"
       },
@@ -2439,6 +2442,7 @@
     "node_modules/@floating-ui/dom": {
       "version": "1.7.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
@@ -3848,6 +3852,40 @@
         "node": ">=18"
       }
     },
+    "node_modules/@microsoft/signalr": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-10.0.0.tgz",
+      "integrity": "sha512-0BRqz/uCx3JdrOqiqgFhih/+hfTERaUfCZXFB52uMaZJrKaPRzHzMuqVsJC/V3pt7NozcNXGspjKiQEK+X7P2w==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "eventsource": "^2.0.2",
+        "fetch-cookie": "^2.0.3",
+        "node-fetch": "^2.6.7",
+        "ws": "^7.5.10"
+      }
+    },
+    "node_modules/@microsoft/signalr/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@miyaneee/rollup-plugin-json5": {
       "version": "1.2.0",
       "license": "MIT",
@@ -3964,6 +4002,7 @@
     "node_modules/@nuxt/content": {
       "version": "3.10.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/kit": "^4.2.2",
         "@nuxtjs/mdc": "^0.19.2",
@@ -5090,6 +5129,7 @@
     "node_modules/@nuxt/ui/node_modules/@tiptap/pm": {
       "version": "3.13.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -7712,6 +7752,7 @@
     "node_modules/@tiptap/core": {
       "version": "3.14.0",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -7959,6 +8000,7 @@
     "node_modules/@tiptap/extension-list": {
       "version": "3.14.0",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -8085,6 +8127,7 @@
     "node_modules/@tiptap/extensions": {
       "version": "3.14.0",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -8112,6 +8155,7 @@
     "node_modules/@tiptap/pm": {
       "version": "3.14.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -8174,6 +8218,7 @@
     "node_modules/@tiptap/suggestion": {
       "version": "3.13.0",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -8186,6 +8231,7 @@
     "node_modules/@tiptap/vue-3": {
       "version": "3.13.0",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -8260,7 +8306,8 @@
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
@@ -8345,6 +8392,7 @@
     "node_modules/@typescript-eslint/parser": {
       "version": "8.51.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -8543,6 +8591,7 @@
     "node_modules/@unhead/vue": {
       "version": "2.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hookable": "^5.5.3",
         "unhead": "2.1.1"
@@ -9063,6 +9112,7 @@
     "node_modules/@vue/compiler-sfc": {
       "version": "3.5.26",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@vue/compiler-core": "3.5.26",
@@ -9086,7 +9136,6 @@
     "node_modules/@vue/devtools-api": {
       "version": "7.7.9",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-kit": "^7.7.9"
       }
@@ -9094,7 +9143,6 @@
     "node_modules/@vue/devtools-api/node_modules/@vue/devtools-kit": {
       "version": "7.7.9",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-shared": "^7.7.9",
         "birpc": "^2.3.0",
@@ -9108,15 +9156,13 @@
     "node_modules/@vue/devtools-api/node_modules/@vue/devtools-shared": {
       "version": "7.7.9",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "rfdc": "^1.4.1"
       }
     },
     "node_modules/@vue/devtools-api/node_modules/perfect-debounce": {
       "version": "1.0.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@vue/devtools-core": {
       "version": "8.0.5",
@@ -9209,6 +9255,7 @@
     "node_modules/@vueuse/core": {
       "version": "14.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/web-bluetooth": "^0.0.21",
         "@vueuse/metadata": "14.1.0",
@@ -9326,6 +9373,7 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9643,6 +9691,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
       "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -9776,6 +9825,7 @@
       "version": "12.5.0",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -9894,6 +9944,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -11099,7 +11150,8 @@
     },
     "node_modules/embla-carousel": {
       "version": "8.6.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-auto-height": {
       "version": "8.6.0",
@@ -11381,6 +11433,7 @@
       "version": "0.27.2",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -11459,6 +11512,7 @@
     "node_modules/eslint": {
       "version": "9.39.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11973,6 +12027,15 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "8.0.1",
       "license": "MIT",
@@ -12093,6 +12156,16 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fetch-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-2.2.0.tgz",
+      "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
+      "license": "Unlicense",
+      "dependencies": {
+        "set-cookie-parser": "^2.4.8",
+        "tough-cookie": "^4.0.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -12892,6 +12965,7 @@
     "node_modules/fuse.js": {
       "version": "7.1.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -14452,7 +14526,6 @@
     "node_modules/isomorphic.js": {
       "version": "0.2.5",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -14757,7 +14830,6 @@
     "node_modules/lib0": {
       "version": "0.2.117",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -16948,6 +17020,7 @@
     "node_modules/nuxt": {
       "version": "4.2.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dxup/nuxt": "^0.2.2",
         "@nuxt/cli": "^3.31.1",
@@ -17585,6 +17658,7 @@
     "node_modules/nuxt/node_modules/oxc-parser": {
       "version": "0.102.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "^0.102.0"
       },
@@ -17929,6 +18003,7 @@
     "node_modules/oxc-parser": {
       "version": "0.105.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "^0.105.0"
       },
@@ -18257,6 +18332,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -18828,6 +18904,7 @@
     "node_modules/prosemirror-model": {
       "version": "1.25.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -18851,6 +18928,7 @@
     "node_modules/prosemirror-state": {
       "version": "1.4.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -18891,6 +18969,7 @@
     "node_modules/prosemirror-view": {
       "version": "1.41.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -18906,6 +18985,18 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.3",
@@ -18941,6 +19032,12 @@
           "url": "https://github.com/sponsors/sxzz"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
       "license": "MIT"
     },
     "node_modules/queue-microtask": {
@@ -19480,6 +19577,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
     "node_modules/reserved-identifiers": {
       "version": "1.2.0",
       "license": "MIT",
@@ -19541,6 +19644,7 @@
     "node_modules/rollup": {
       "version": "4.54.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -19821,6 +19925,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -20659,6 +20769,7 @@
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
@@ -20683,7 +20794,8 @@
     },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -20824,6 +20936,7 @@
     "node_modules/terser": {
       "version": "5.44.1",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -20931,6 +21044,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/tr46": {
@@ -21090,6 +21227,7 @@
     "node_modules/typescript": {
       "version": "5.9.3",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21592,6 +21730,7 @@
       "version": "1.11.1",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },
@@ -21834,6 +21973,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "license": "MIT"
@@ -21987,6 +22136,7 @@
     "node_modules/vite": {
       "version": "7.3.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -22341,6 +22491,7 @@
     "node_modules/vue": {
       "version": "3.5.26",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.26",
         "@vue/compiler-sfc": "3.5.26",
@@ -22420,6 +22571,7 @@
     "node_modules/vue-eslint-parser": {
       "version": "10.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0",
@@ -22451,6 +22603,7 @@
     "node_modules/vue-i18n": {
       "version": "11.2.8",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@intlify/core-base": "11.2.8",
         "@intlify/shared": "11.2.8",
@@ -22486,6 +22639,7 @@
     "node_modules/vue-router": {
       "version": "4.6.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.4"
       },
@@ -22858,6 +23012,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -22992,6 +23147,7 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -23502,6 +23658,7 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/Homassy.Web/package.json
+++ b/Homassy.Web/package.json
@@ -13,6 +13,7 @@
     "@iconify-json/heroicons": "^1.2.3",
     "@iconify-json/lucide": "^1.2.82",
     "@internationalized/date": "^3.10.1",
+    "@microsoft/signalr": "^10.0.0",
     "@nuxt/content": "^3.9.0",
     "@nuxt/eslint": "^1.12.1",
     "@nuxt/hints": "^1.0.0-alpha.4",


### PR DESCRIPTION
Each shopping list now has its own realtime channel. Opening a list joins its group and returns the current items (no extra fetch); any create, update, delete or purchase by anyone is pushed live to everyone viewing the list, so the UI stays current without manual refresh. Switching lists leaves the old channel and joins the new one.

Backend (Homassy.API):
- ShoppingListHub at /hubs/shopping-list, authorized through the existing Kratos session middleware (session cookie rides the WS handshake).
- ShoppingListRealtime broadcaster; ShoppingListFunctions broadcasts ItemUpserted/ItemDeleted/ListUpdated/ListDeleted after each commit, reusing a hydrated BuildItemInfo for snapshot and broadcast payloads.
- AddSignalR with camelCase payloads; hub mapped with the CORS policy.

Frontend (Homassy.Web):
- useShoppingListSocket composable: single connection, withCredentials, automatic reconnect + re-join, REST fallback.
- shopping-lists page joins on open, leaves on switch, merges live events in place, and skips the post-mutation refetch while connected.