### PR TITLE
fix: color calendar event cards by calendar and remove event modal

### DIFF
--- a/Homassy.API/Functions/ExternalCalendarFunctions.cs
+++ b/Homassy.API/Functions/ExternalCalendarFunctions.cs
@@ -171,7 +171,8 @@ namespace Homassy.API.Functions
                                 Start = eventStart,
                                 Detail = ev.Description,
                                 RelatedEntityPublicId = null,
-                                Color = calendar.Color
+                                Color = calendar.Color,
+                                IsAllDay = ev.IsAllDay
                             });
                         }
                     }

--- a/Homassy.API/Models/Calendar/CalendarEventInfo.cs
+++ b/Homassy.API/Models/Calendar/CalendarEventInfo.cs
@@ -17,5 +17,6 @@ namespace Homassy.API.Models.Calendar
         public string? Detail { get; set; }
         public Guid? RelatedEntityPublicId { get; set; }
         public string? Color { get; set; }
+        public bool IsAllDay { get; set; }
     }
 }

--- a/Homassy.Web/app/components/calendar/CalendarEventCard.vue
+++ b/Homassy.Web/app/components/calendar/CalendarEventCard.vue
@@ -1,14 +1,18 @@
 <template>
   <div
-    class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3 border-l-4 cursor-pointer active:opacity-70 transition-opacity"
-    :class="borderClass"
-    @click="emit('click')"
+    class="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3 border-l-4"
+    :class="isExternal ? '' : borderClass"
+    :style="isExternal ? { borderLeftColor: color ?? '#3B82F6' } : {}"
   >
     <div class="flex items-start justify-between gap-2">
       <span class="text-sm font-medium text-gray-900 dark:text-gray-100 leading-snug">
         {{ title }}
       </span>
-      <span class="shrink-0 text-xs rounded px-1.5 py-0.5 leading-tight" :class="chipClass">
+      <span
+        class="shrink-0 text-xs rounded px-1.5 py-0.5 leading-tight"
+        :class="isExternal ? 'text-white' : chipClass"
+        :style="isExternal ? { backgroundColor: color ?? '#3B82F6' } : {}"
+      >
         {{ t(`pages.calendar.eventTypes.${eventTypeKey}`) }}
       </span>
     </div>
@@ -25,11 +29,12 @@ const props = defineProps<{
   title: string
   eventType: CalendarEventType
   detail: string | null
+  color: string | null
 }>()
 
-const emit = defineEmits<{ click: [] }>()
-
 const { t } = useI18n()
+
+const isExternal = computed(() => props.eventType === CalendarEventType.ExternalCalendar)
 
 const borderClass = computed(() => {
   switch (props.eventType) {
@@ -58,6 +63,7 @@ const eventTypeKey = computed(() => {
     case CalendarEventType.InventoryExpiration: return 'inventoryExpiration'
     case CalendarEventType.AutomationExecution: return 'automationExecution'
     case CalendarEventType.ShoppingListDeadline: return 'shoppingListDeadline'
+    case CalendarEventType.ExternalCalendar: return 'externalCalendar'
     default: return 'inventoryExpiration'
   }
 })

--- a/Homassy.Web/app/pages/calendar.vue
+++ b/Homassy.Web/app/pages/calendar.vue
@@ -114,9 +114,8 @@
                   v-for="(ev, ei) in cell.events"
                   :key="ei"
                   class="text-xs rounded px-1 py-0.5 truncate leading-tight"
-                  :class="ev.eventType !== CalendarEventType.ExternalCalendar ? [chipClass(ev.eventType), ev.eventType !== CalendarEventType.InventoryExpiration ? 'cursor-pointer' : 'cursor-default'] : 'text-white cursor-pointer'"
+                  :class="ev.eventType !== CalendarEventType.ExternalCalendar ? chipClass(ev.eventType) : 'text-white'"
                   :style="ev.eventType === CalendarEventType.ExternalCalendar ? { backgroundColor: ev.color ?? '#3B82F6' } : {}"
-                  @click.stop="openEventModal(ev)"
                 >
                   {{ ev.title }}
                 </div>
@@ -169,7 +168,7 @@
                   :title="item.data.title"
                   :event-type="item.data.eventType"
                   :detail="item.data.detail"
-                  @click="openEventModal(item.data)"
+                  :color="item.data.color"
                 />
                 <CalendarActivityCard
                   v-else-if="item.kind === 'activity'"
@@ -191,35 +190,6 @@
         </div>
       </div>
     </div>
-
-    <!-- Event detail modal -->
-    <UModal :open="!!selectedEvent" @update:open="(val) => { if (!val) selectedEvent = null }">
-      <template v-if="selectedEvent" #title>
-        {{ selectedEvent.title }}
-      </template>
-      <template v-if="selectedEvent" #default>
-        <div class="space-y-3 p-4">
-          <div class="flex items-center gap-2">
-            <span
-              class="inline-block w-3 h-3 rounded-full"
-              :class="selectedEvent.eventType !== CalendarEventType.ExternalCalendar ? dotClass(selectedEvent.eventType) : ''"
-              :style="selectedEvent.eventType === CalendarEventType.ExternalCalendar ? { backgroundColor: selectedEvent.color ?? '#3B82F6' } : {}"
-            />
-            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">
-              {{ t(`pages.calendar.eventTypes.${eventTypeKey(selectedEvent.eventType)}`) }}
-            </span>
-          </div>
-          <div class="text-sm text-gray-600 dark:text-gray-400">
-            <span class="font-medium">{{ t('pages.calendar.date') }}:</span>
-            {{ formatDate(selectedEvent.dateStr) }}
-          </div>
-          <div v-if="selectedEvent.detail" class="text-sm text-gray-600 dark:text-gray-400">
-            <span class="font-medium">{{ t('pages.calendar.detail') }}:</span>
-            {{ selectedEvent.detail }}
-          </div>
-        </div>
-      </template>
-    </UModal>
   </div>
 </template>
 
@@ -249,6 +219,7 @@ interface CalEvent {
   detail: string | null
   relatedPublicId: string | null
   color: string | null
+  isAllDay: boolean
 }
 
 interface CalActivity {
@@ -276,7 +247,6 @@ const isLoading = ref(false)
 const calendarEvents = ref<CalEvent[]>([])
 const calendarActivities = ref<CalActivity[]>([])
 const externalCalendars = ref<ExternalCalendarResponse[]>([])
-const selectedEvent = ref<CalEvent | null>(null)
 
 const selectedDay = ref<string | null>(toLocalDate(new Date()))
 const visibleCount = ref(5)
@@ -352,6 +322,9 @@ const selectedDayItems = computed((): DayItem[] => {
     .map(a => ({ kind: 'activity' as const, data: a }))
 
   return [...events, ...activities].sort((a, b) => {
+    const aAllDay = a.kind === 'event' && a.data.isAllDay
+    const bAllDay = b.kind === 'event' && b.data.isAllDay
+    if (aAllDay !== bAllDay) return aAllDay ? -1 : 1
     const ta = a.kind === 'event' ? a.data.startAt : a.data.timestamp
     const tb = b.kind === 'event' ? b.data.startAt : b.data.timestamp
     return tb.localeCompare(ta)
@@ -365,12 +338,6 @@ const visibleItems = computed(() =>
 const hasMore = computed(() =>
   visibleCount.value < selectedDayItems.value.length
 )
-
-const openEventModal = (ev: CalEvent) => {
-  if (ev.eventType !== CalendarEventType.InventoryExpiration) {
-    selectedEvent.value = ev
-  }
-}
 
 const selectDay = (dateStr: string) => {
   if (selectedDay.value === dateStr) return
@@ -416,7 +383,8 @@ const mapEvents = (items: CalendarEventInfo[]): CalEvent[] =>
     startAt: item.start,
     detail: item.detail,
     relatedPublicId: item.relatedEntityPublicId,
-    color: item.color ?? null
+    color: item.color ?? null,
+    isAllDay: item.isAllDay ?? false
   }))
 
 const mapActivities = (items: ActivityInfo[]): CalActivity[] =>
@@ -500,16 +468,6 @@ const chipClass = (type: CalendarEventType): string => {
       return 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
     default:
       return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300'
-  }
-}
-
-const eventTypeKey = (type: CalendarEventType): string => {
-  switch (type) {
-    case CalendarEventType.InventoryExpiration: return 'inventoryExpiration'
-    case CalendarEventType.AutomationExecution: return 'automationExecution'
-    case CalendarEventType.ShoppingListDeadline: return 'shoppingListDeadline'
-    case CalendarEventType.ExternalCalendar: return 'externalCalendar'
-    default: return 'inventoryExpiration'
   }
 }
 

--- a/Homassy.Web/app/types/calendar.ts
+++ b/Homassy.Web/app/types/calendar.ts
@@ -13,4 +13,5 @@ export interface CalendarEventInfo {
   detail: string | null
   relatedEntityPublicId: string | null
   color: string | null
+  isAllDay: boolean
 }


### PR DESCRIPTION
## What changed

Fixes how external (iCal) calendar events render on the Calendar page:

- **Color** – an external calendar event card's left border and badge now take the owning calendar's own color (instead of the type-based fixed color).
- **Label** – the badge now reads "External calendar" instead of the wrong "Expiring product". Cause: `CalendarEventCard`'s `eventTypeKey` had no `ExternalCalendar` case and fell through the `default` branch to `inventoryExpiration`.
- **Modal removed** – neither the event card nor the month-grid chip is clickable anymore, and the detail modal is gone entirely. Clicking a cell still selects the day.
- **All-day ordering** – in the day list, all-day events are pinned to the top; the rest keep their start-time ordering.

The backend already computed and cached the iCal `IsAllDay` flag; it is now forwarded onto `CalendarEventInfo` so the UI can distinguish all-day events.

## Files touched

- `Homassy.API/Models/Calendar/CalendarEventInfo.cs` – new `IsAllDay` field
- `Homassy.API/Functions/ExternalCalendarFunctions.cs` – forward `IsAllDay`
- `Homassy.Web/app/types/calendar.ts` – `isAllDay` in the type
- `Homassy.Web/app/components/calendar/CalendarEventCard.vue` – color prop, badge fix, click removed
- `Homassy.Web/app/pages/calendar.vue` – modal removed, ordering, color passthrough
