### PR TITLE
fix: expand recurring and multi-day external calendar events

### DIFF
--- a/Homassy.API/Functions/ExternalCalendarFunctions.cs
+++ b/Homassy.API/Functions/ExternalCalendarFunctions.cs
@@ -169,6 +169,7 @@ namespace Homassy.API.Functions
                                 Title = ev.Title,
                                 EventType = CalendarEventType.ExternalCalendar,
                                 Start = eventStart,
+                                End = ev.End,
                                 Detail = ev.Description,
                                 RelatedEntityPublicId = null,
                                 Color = calendar.Color,
@@ -199,28 +200,7 @@ namespace Homassy.API.Functions
                 var icsContent = await httpClient.GetStringAsync(calendar.ICalUrl, ct);
                 icsContent = SanitizeICalContent(icsContent);
 
-                var calendarEvents = LoadEventsResiliently(icsContent, calendar.PublicId);
-                var events = new List<CachedICalEvent>();
-
-                foreach (var ev in calendarEvents)
-                {
-                    var uid = ev.Uid ?? Guid.NewGuid().ToString();
-                    var title = ev.Summary ?? string.Empty;
-                    var isAllDay = ev.IsAllDay;
-                    var start = ev.DtStart?.AsSystemLocal ?? DateTime.UtcNow;
-                    var end = ev.DtEnd?.AsSystemLocal;
-                    var description = ev.Description;
-
-                    events.Add(new CachedICalEvent
-                    {
-                        Uid = uid,
-                        Title = title,
-                        Start = start,
-                        End = end,
-                        Description = description,
-                        IsAllDay = isAllDay
-                    });
-                }
+                var events = LoadAndExpandEvents(icsContent, calendar.PublicId);
 
                 calendar.CachedEventsJson = JsonSerializer.Serialize(events, JsonOptions);
                 calendar.LastSyncedAt = DateTime.UtcNow;
@@ -310,16 +290,22 @@ namespace Homassy.API.Functions
         }
 
         /// <summary>
-        /// Loads events from sanitized iCal text without letting one bad event abort the whole feed.
-        /// Fast path parses the entire feed; if that throws, falls back to parsing each VEVENT block
-        /// on its own (wrapped in a minimal VCALENDAR that retains the feed's VTIMEZONE blocks so
-        /// TZID-based start/end times still resolve). Events that still fail to parse are skipped.
+        /// Loads events from sanitized iCal text and expands recurrences into concrete occurrences
+        /// without letting one bad event abort the whole feed. Fast path parses + expands the entire
+        /// feed; if that throws, falls back to parsing each VEVENT block on its own (wrapped in a
+        /// minimal VCALENDAR that retains the feed's VTIMEZONE blocks so TZID-based start/end times
+        /// still resolve). Events that still fail to parse are skipped.
         /// </summary>
-        private static List<CalendarEvent> LoadEventsResiliently(string ics, Guid calendarId)
+        private static List<CachedICalEvent> LoadAndExpandEvents(string ics, Guid calendarId)
         {
+            // Recurrence rules can be unbounded, so expansion is limited to a rolling window.
+            // Sync runs hourly (and on startup), so the window keeps sliding forward over time.
+            var windowStart = DateTime.Now.AddMonths(-2);
+            var windowEnd = DateTime.Now.AddMonths(12);
+
             try
             {
-                return Calendar.Load(ics).Events.ToList();
+                return ExpandCalendar(Calendar.Load(ics), windowStart, windowEnd, calendarId);
             }
             catch (Exception ex)
             {
@@ -328,7 +314,7 @@ namespace Homassy.API.Functions
                     calendarId);
             }
 
-            var events = new List<CalendarEvent>();
+            var events = new List<CachedICalEvent>();
             var tzPrefix = string.Concat(ExtractComponentBlocks(ics, "VTIMEZONE"));
 
             foreach (var vevent in ExtractComponentBlocks(ics, "VEVENT"))
@@ -336,7 +322,7 @@ namespace Homassy.API.Functions
                 var single = $"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Homassy//EN\r\n{tzPrefix}{vevent}END:VCALENDAR\r\n";
                 try
                 {
-                    events.AddRange(Calendar.Load(single).Events);
+                    events.AddRange(ExpandCalendar(Calendar.Load(single), windowStart, windowEnd, calendarId));
                 }
                 catch (Exception ex)
                 {
@@ -346,6 +332,63 @@ namespace Homassy.API.Functions
 
             return events;
         }
+
+        /// <summary>
+        /// Expands a parsed calendar into <see cref="CachedICalEvent"/>s. Recurring events and any
+        /// single events that fall inside the window are expanded via Ical.Net's occurrence engine
+        /// (RRULE/RDATE expanded, EXDATE excluded, RECURRENCE-ID overrides applied). Non-recurring
+        /// events whose only occurrence lies entirely outside the window are added directly so distant
+        /// single events are not lost. If occurrence expansion itself throws on a malformed recurrence,
+        /// every master event is stored once so we never regress to zero events.
+        /// </summary>
+        private static List<CachedICalEvent> ExpandCalendar(Calendar cal, DateTime windowStart, DateTime windowEnd, Guid calendarId)
+        {
+            var result = new List<CachedICalEvent>();
+
+            try
+            {
+                foreach (var occ in cal.GetOccurrences(windowStart, windowEnd))
+                {
+                    if (occ.Source is not CalendarEvent ev) continue;
+                    result.Add(MapEvent(ev, occ.Period.StartTime?.AsSystemLocal, occ.Period.EndTime?.AsSystemLocal));
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex,
+                    "External calendar {CalendarId}: occurrence expansion failed, storing master events only",
+                    calendarId);
+                return cal.Events.Select(ev => MapEvent(ev, ev.DtStart?.AsSystemLocal, ev.DtEnd?.AsSystemLocal)).ToList();
+            }
+
+            // Safety net: a non-recurring event that does not overlap the window is dropped by
+            // GetOccurrences. Add those directly (overlapping ones were already returned above).
+            foreach (var ev in cal.Events)
+            {
+                if (ev.RecurrenceRules?.Count > 0 || ev.RecurrenceDates?.Count > 0) continue;
+
+                var start = ev.DtStart?.AsSystemLocal;
+                if (start == null) continue;
+
+                var end = ev.DtEnd?.AsSystemLocal ?? start.Value;
+                var overlapsWindow = start.Value <= windowEnd && end >= windowStart;
+                if (overlapsWindow) continue;
+
+                result.Add(MapEvent(ev, start, ev.DtEnd?.AsSystemLocal));
+            }
+
+            return result;
+        }
+
+        private static CachedICalEvent MapEvent(CalendarEvent ev, DateTime? start, DateTime? end) => new()
+        {
+            Uid = ev.Uid ?? Guid.NewGuid().ToString(),
+            Title = ev.Summary ?? string.Empty,
+            Start = start ?? DateTime.UtcNow,
+            End = end,
+            Description = ev.Description,
+            IsAllDay = ev.IsAllDay
+        };
 
         /// <summary>
         /// Extracts each <c>BEGIN:{component} … END:{component}</c> block (inclusive) as a CRLF-terminated string.

--- a/Homassy.API/Models/Calendar/CalendarEventInfo.cs
+++ b/Homassy.API/Models/Calendar/CalendarEventInfo.cs
@@ -14,6 +14,7 @@ namespace Homassy.API.Models.Calendar
         public string Title { get; set; } = string.Empty;
         public CalendarEventType EventType { get; set; }
         public DateTime Start { get; set; }
+        public DateTime? End { get; set; }
         public string? Detail { get; set; }
         public Guid? RelatedEntityPublicId { get; set; }
         public string? Color { get; set; }

--- a/Homassy.Web/app/pages/calendar.vue
+++ b/Homassy.Web/app/pages/calendar.vue
@@ -162,7 +162,7 @@
               ref="scrollContainer"
               class="space-y-2 overflow-y-auto flex-1 min-h-0 lg:flex-none lg:max-h-[calc(100vh-8rem)]"
             >
-              <template v-for="item in visibleItems" :key="item.kind + '-' + item.data.publicId">
+              <template v-for="(item, idx) in visibleItems" :key="item.kind + '-' + item.data.publicId + '-' + idx">
                 <CalendarEventCard
                   v-if="item.kind === 'event'"
                   :title="item.data.title"
@@ -215,6 +215,7 @@ interface CalEvent {
   title: string
   eventType: CalendarEventType
   dateStr: string
+  endStr: string | null
   startAt: string
   detail: string | null
   relatedPublicId: string | null
@@ -269,10 +270,49 @@ const dayHeaders = computed(() => {
   })
 })
 
+// Upper bound on the number of days a single event may span, so a malformed
+// feed (e.g. an event ending years after it starts) can't blow up the buckets.
+const MAX_SPAN_DAYS = 370
+
+// All `YYYY-MM-DD` days an event covers. Single-day events return just their
+// start day; multi-day events are listed on every day they span.
+const eventDayKeys = (ev: CalEvent): string[] => {
+  const startKey = ev.dateStr
+  if (!ev.endStr) return [startKey]
+
+  const endKey = ev.endStr.split('T')[0] ?? ev.endStr
+  if (endKey <= startKey) return [startKey]
+
+  const parse = (key: string): Date | null => {
+    const [y, m, d] = key.split('-').map(Number)
+    if (!y || !m || !d) return null
+    return new Date(y, m - 1, d)
+  }
+
+  const start = parse(startKey)
+  const end = parse(endKey)
+  if (!start || !end) return [startKey]
+
+  // iCal all-day events use an exclusive DTEND (midnight after the last day),
+  // so the last visible day is end - 1; timed events end on the end date itself.
+  if (ev.isAllDay) end.setDate(end.getDate() - 1)
+  if (end <= start) return [startKey]
+
+  const keys: string[] = []
+  const cur = new Date(start)
+  while (cur <= end && keys.length < MAX_SPAN_DAYS) {
+    keys.push(toLocalDate(cur))
+    cur.setDate(cur.getDate() + 1)
+  }
+  return keys
+}
+
 const eventsByDate = computed(() => {
   const map: Record<string, CalEvent[]> = {}
   for (const ev of calendarEvents.value) {
-    ;(map[ev.dateStr] ??= []).push(ev)
+    for (const key of eventDayKeys(ev)) {
+      ;(map[key] ??= []).push(ev)
+    }
   }
   return map
 })
@@ -380,6 +420,7 @@ const mapEvents = (items: CalendarEventInfo[]): CalEvent[] =>
     title: item.title,
     eventType: item.eventType,
     dateStr: item.start.split('T')[0] ?? item.start,
+    endStr: item.end ?? null,
     startAt: item.start,
     detail: item.detail,
     relatedPublicId: item.relatedEntityPublicId,

--- a/Homassy.Web/app/types/calendar.ts
+++ b/Homassy.Web/app/types/calendar.ts
@@ -10,6 +10,7 @@ export interface CalendarEventInfo {
   title: string
   eventType: CalendarEventType
   start: string
+  end: string | null
   detail: string | null
   relatedEntityPublicId: string | null
   color: string | null


### PR DESCRIPTION
## Problem

For events synced from external iCal calendars:

- **Recurring events** (RRULE): only the first occurrence showed up; the rest were missing.
- **Multi-day events**: only filed under the start day — intermediate and end days were not shown.

## Solution

**Backend**
- Sync now expands occurrences via the Ical.Net `GetOccurrences` engine over a rolling **-2 / +12 month** window (RRULE/RDATE expanded, EXDATE excluded, RECURRENCE-ID overrides applied). Sync runs hourly, so the window keeps sliding forward.
- Non-recurring events outside the window are kept directly (no regression for distant events, and no duplicates).
- If the occurrence engine fails on a malformed feed, it falls back to storing each master once — it never regresses to zero events.
- `CalendarEventInfo` now carries the event `End`.

**Frontend**
- Multi-day events are listed on every day they span. The iCal all-day `DTEND` is exclusive, so for all-day events the last visible day is `end - 1`; for timed events the end date is inclusive.
- Upper bound (370 days) guards against a malformed feed.
- Fixed duplicate Vue `:key` in the day panel (external events all share the calendar `publicId`).

## Affected files

| File | Change |
|---|---|
| `Homassy.API/Functions/ExternalCalendarFunctions.cs` | RRULE expansion via `GetOccurrences`; pass through `End` |
| `Homassy.API/Models/Calendar/CalendarEventInfo.cs` | new `End` field |
| `Homassy.Web/app/types/calendar.ts` | `end` field |
| `Homassy.Web/app/pages/calendar.vue` | multi-day bucketing, `:key` fix |
