### PR TITLE
feat(ui): persistent page header with in-header search

### DIFF
--- a/Homassy.Web/app/app.config.ts
+++ b/Homassy.Web/app/app.config.ts
@@ -4,6 +4,11 @@
       primary: 'mocha',
       neutral: 'slate',
       success: 'mocha'
+    },
+    drawer: {
+      slots: {
+        content: 'max-w-2xl mx-auto'
+      }
     }
   }
 })

--- a/Homassy.Web/app/assets/css/main.css
+++ b/Homassy.Web/app/assets/css/main.css
@@ -17,7 +17,15 @@
   --color-mocha-950: #3F3027;
 }
 
-/* Page content cross-fade on navigation (the bottom nav stays fixed in the layout). */
+/* Persistent header height — measured at runtime by AppHeader.vue and published
+   as this custom property. The default keeps layouts sane before/without a
+   measurement (SSR, first paint) so pages can offset content with
+   var(--app-header-height) safely. */
+:root {
+  --app-header-height: 5.5rem;
+}
+
+/* Page content cross-fade on navigation (the bottom nav + header stay fixed in the layout). */
 .page-enter-active,
 .page-leave-active {
   transition: opacity 0.18s ease, transform 0.18s ease;

--- a/Homassy.Web/app/components/AppHeader.vue
+++ b/Homassy.Web/app/components/AppHeader.vue
@@ -5,7 +5,7 @@
     :style="{ paddingTop: 'env(safe-area-inset-top)' }"
   >
     <div class="px-6 sm:px-10 lg:px-16 py-4">
-      <div class="flex items-center gap-3">
+      <div class="flex flex-wrap items-center gap-3">
         <!-- Back button -->
         <NuxtLink v-if="header.backTo" :to="header.backTo" class="shrink-0">
           <UButton
@@ -70,6 +70,20 @@
         <!-- Page-specific trailing actions (teleport target). Kept INSIDE UApp
              (not <body>) so it does not hit the isolation/z-index trap that makes
              body-teleported overlays paint above the nav and swallow taps. -->
+        <!-- Page search (teleport target). Full-width second row on mobile; inline on
+             the right, next to the title, from md: up. A skeleton stands in while the
+             header is stale/loading, matching the title skeleton above. Kept inside UApp
+             (not <body>) so it does not hit the teleport isolation/z-index trap. -->
+        <USkeleton
+          v-if="showSearchSkeleton"
+          class="order-last w-full md:order-none md:w-80 h-9 rounded-md"
+        />
+        <div
+          v-show="!showSearchSkeleton"
+          id="app-header-search"
+          class="order-last w-full md:order-none md:w-80 empty:hidden"
+        />
+
         <div id="app-header-actions" class="shrink-0 flex items-center gap-2 empty:hidden" />
       </div>
     </div>
@@ -95,6 +109,10 @@ const isStale = computed(() =>
 )
 
 const showTitleSkeleton = computed(() => isStale.value || !header.value.title)
+
+// Search lives in a teleport target below the title; skeleton it in lockstep with
+// the title whenever the header is stale/loading, but only for pages that have one.
+const showSearchSkeleton = computed(() => isStale.value && !!header.value.hasSearch)
 
 // The subtitle row only appears once the header is committed for the current
 // route, so navigation shows a single title skeleton (no phantom subtitle line).

--- a/Homassy.Web/app/components/AppHeader.vue
+++ b/Homassy.Web/app/components/AppHeader.vue
@@ -1,0 +1,131 @@
+<template>
+  <header
+    ref="headerRef"
+    class="fixed inset-x-0 top-0 z-40 border-b border-gray-200 dark:border-gray-800 bg-default/95 backdrop-blur"
+    :style="{ paddingTop: 'env(safe-area-inset-top)' }"
+  >
+    <div class="px-6 sm:px-10 lg:px-16 py-4">
+      <div class="flex items-center gap-3">
+        <!-- Back button -->
+        <NuxtLink v-if="header.backTo" :to="header.backTo" class="shrink-0">
+          <UButton
+            icon="i-lucide-arrow-left"
+            color="neutral"
+            variant="ghost"
+            :aria-label="t('common.back')"
+          />
+        </NuxtLink>
+
+        <!-- Leading icon (or skeleton) -->
+        <USkeleton v-if="showTitleSkeleton" class="h-7 w-7 rounded-md shrink-0" />
+        <UIcon
+          v-else-if="header.icon"
+          :name="header.icon"
+          class="h-7 w-7 text-primary-500 shrink-0"
+        />
+
+        <!-- Title + subtitle column -->
+        <div class="min-w-0 flex-1">
+          <!-- Title row -->
+          <div class="flex items-center gap-1.5">
+            <USkeleton v-if="showTitleSkeleton" class="h-7 w-40 rounded-md" />
+            <template v-else>
+              <h1 class="text-2xl font-semibold leading-tight truncate">{{ header.title }}</h1>
+              <UPopover v-if="header.info">
+                <UButton
+                  icon="i-lucide-info"
+                  color="neutral"
+                  variant="ghost"
+                  size="xs"
+                  :aria-label="t('common.info')"
+                />
+                <template #content>
+                  <p class="p-3 max-w-xs text-sm text-gray-600 dark:text-gray-400">
+                    {{ header.info }}
+                  </p>
+                </template>
+              </UPopover>
+            </template>
+          </div>
+
+          <!-- Subtitle row -->
+          <div v-if="showSubtitleRow" class="flex items-center gap-1.5 mt-0.5">
+            <USkeleton v-if="showSubtitleSkeleton" class="h-4 w-28 rounded" />
+            <template v-else>
+              <span
+                v-if="header.subtitleColor"
+                class="w-2.5 h-2.5 rounded-full shrink-0"
+                :style="{ backgroundColor: header.subtitleColor }"
+              />
+              <span class="text-sm text-gray-600 dark:text-gray-400 truncate">{{ header.subtitle }}</span>
+              <UIcon
+                v-if="header.subtitleIcon"
+                :name="header.subtitleIcon"
+                class="h-3.5 w-3.5 text-primary-500 shrink-0"
+              />
+            </template>
+          </div>
+        </div>
+
+        <!-- Page-specific trailing actions (teleport target). Kept INSIDE UApp
+             (not <body>) so it does not hit the isolation/z-index trap that makes
+             body-teleported overlays paint above the nav and swallow taps. -->
+        <div id="app-header-actions" class="shrink-0 flex items-center gap-2 empty:hidden" />
+      </div>
+    </div>
+  </header>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { useRoute } from 'vue-router'
+
+const { t } = useI18n()
+const route = useRoute()
+const header = usePageHeaderState()
+
+// Gate on mount to avoid an SSR/hydration mismatch: SSR and the first client
+// render both show the skeleton; after mount the committed state drives it.
+const mounted = ref(false)
+
+// True while the header belongs to a different route (mid-navigation) or the
+// page has flagged an async load — the "skeleton, then load" window.
+const isStale = computed(() =>
+  !mounted.value || header.value.path !== route.path || !!header.value.loading
+)
+
+const showTitleSkeleton = computed(() => isStale.value || !header.value.title)
+
+// The subtitle row only appears once the header is committed for the current
+// route, so navigation shows a single title skeleton (no phantom subtitle line).
+const showSubtitleRow = computed(() =>
+  mounted.value
+  && header.value.path === route.path
+  && (!!header.value.hasSubtitle || header.value.subtitle != null)
+)
+
+const showSubtitleSkeleton = computed(() =>
+  showSubtitleRow.value && (!!header.value.loading || header.value.subtitle == null)
+)
+
+// Publish the measured header height as --app-header-height so the layout can pad
+// UMain and pages can offset sticky sub-bars / scroll containers below it.
+const headerRef = ref<HTMLElement | null>(null)
+let observer: ResizeObserver | null = null
+
+function measure() {
+  if (headerRef.value) {
+    document.documentElement.style.setProperty('--app-header-height', `${headerRef.value.offsetHeight}px`)
+  }
+}
+
+onMounted(() => {
+  mounted.value = true
+  if (!import.meta.client || !headerRef.value) return
+  observer = new ResizeObserver(measure)
+  observer.observe(headerRef.value)
+  measure()
+})
+
+onBeforeUnmount(() => observer?.disconnect())
+</script>

--- a/Homassy.Web/app/components/ListFilterBar.vue
+++ b/Homassy.Web/app/components/ListFilterBar.vue
@@ -1,23 +1,12 @@
 <template>
   <div>
-    <!-- Fixed Header -->
+    <!-- Sticky search + filter sub-bar. The page identity (back arrow, icon,
+         title) now lives in the persistent AppHeader via usePageHeader (script);
+         this bar sticks just below it, aligned with the content below. -->
     <div
-      ref="headerRef"
-      class="fixed top-0 left-0 right-0 z-10 bg-white dark:bg-gray-900 px-6 sm:px-10 lg:px-16 py-6 space-y-3"
+      class="sticky z-30 -mx-4 sm:-mx-6 lg:-mx-8 px-6 sm:px-10 lg:px-16 py-3 mb-4 space-y-3 border-b border-gray-200 dark:border-gray-800 bg-default/95 backdrop-blur"
+      :style="{ top: 'var(--app-header-height, 5.5rem)' }"
     >
-      <!-- Title row -->
-      <div class="flex items-center gap-3">
-        <NuxtLink :to="backTo">
-          <UButton
-            icon="i-lucide-arrow-left"
-            color="neutral"
-            variant="ghost"
-          />
-        </NuxtLink>
-        <UIcon :name="icon" class="h-7 w-7 text-primary-500" />
-        <h1 class="text-2xl font-semibold">{{ title }}</h1>
-      </div>
-
       <!-- Search row + filter trigger -->
       <div class="flex items-center gap-2">
         <UFieldGroup size="md" orientation="horizontal" class="flex-1">
@@ -69,9 +58,6 @@
       </div>
     </div>
 
-    <!-- Spacer matching the fixed header height so content flows naturally -->
-    <div :style="{ height: `${headerHeight}px` }" />
-
     <!-- Filter drawer (bottom sheet) -->
     <UDrawer v-model:open="filtersOpen" :title="$t('common.filters.toggle')">
       <template #body>
@@ -103,9 +89,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { ref } from 'vue'
 
-withDefaults(defineProps<{
+const props = withDefaults(defineProps<{
   title: string
   icon: string
   backTo?: string
@@ -123,26 +109,12 @@ const emit = defineEmits<{ 'clear-all': [] }>()
 const search = defineModel<string>('search', { default: '' })
 
 const filtersOpen = ref(false)
-const headerRef = ref<HTMLElement | null>(null)
-// Seed with a sensible default (~the previous pt-40) so content doesn't slip
-// under the fixed header before the ResizeObserver measures the real height.
-const headerHeight = ref(160)
-let observer: ResizeObserver | null = null
 
-const GAP = 8 // small breathing room between the fixed header and content
-
-function measure() {
-  if (headerRef.value) headerHeight.value = headerRef.value.offsetHeight + GAP
-}
-
-onMounted(() => {
-  if (!import.meta.client || !headerRef.value) return
-  observer = new ResizeObserver(measure)
-  observer.observe(headerRef.value)
-  measure()
-})
-
-onBeforeUnmount(() => {
-  observer?.disconnect()
-})
+// The page identity (back arrow + icon + title) is rendered by the persistent
+// AppHeader in the auth layout; feed it from this bar's props.
+usePageHeader(() => ({
+  backTo: props.backTo,
+  icon: props.icon,
+  title: props.title
+}))
 </script>

--- a/Homassy.Web/app/components/ListFilterBar.vue
+++ b/Homassy.Web/app/components/ListFilterBar.vue
@@ -1,62 +1,61 @@
 <template>
   <div>
-    <!-- Sticky search + filter sub-bar. The page identity (back arrow, icon,
-         title) now lives in the persistent AppHeader via usePageHeader (script);
-         this bar sticks just below it, aligned with the content below. -->
-    <div
-      class="sticky z-30 -mx-4 sm:-mx-6 lg:-mx-8 px-6 sm:px-10 lg:px-16 py-3 mb-4 space-y-3 border-b border-gray-200 dark:border-gray-800 bg-default/95 backdrop-blur"
-      :style="{ top: 'var(--app-header-height, 5.5rem)' }"
-    >
-      <!-- Search row + filter trigger -->
-      <div class="flex items-center gap-2">
-        <UFieldGroup size="md" orientation="horizontal" class="flex-1">
-          <UInput
-            v-model="search"
-            trailing-icon="i-lucide-search"
-            :placeholder="searchPlaceholder"
-            class="flex-1"
-          />
-          <slot name="search-trailing" />
-        </UFieldGroup>
-        <UChip :show="filterCount > 0" :text="filterCount" color="primary" size="2xl">
-          <UButton
-            icon="i-lucide-sliders-horizontal"
-            color="neutral"
-            variant="outline"
-            :aria-label="$t('common.filters.toggle')"
-            :aria-expanded="filtersOpen"
-            @click="filtersOpen = true"
-          />
-        </UChip>
-      </div>
+    <!-- Search + filter bar, teleported into the persistent AppHeader (the page
+         identity lives there too via usePageHeader). The header renders a
+         skeleton in this slot while it is stale/loading. -->
+    <Teleport to="#app-header-search">
+      <div class="space-y-3">
+        <!-- Search row + filter trigger -->
+        <div class="flex items-center gap-2">
+          <UFieldGroup size="md" orientation="horizontal" class="flex-1">
+            <UInput
+              v-model="search"
+              trailing-icon="i-lucide-search"
+              :placeholder="searchPlaceholder"
+              class="flex-1"
+            />
+            <slot name="search-trailing" />
+          </UFieldGroup>
+          <UChip :show="filterCount > 0" :text="filterCount" color="primary" size="2xl">
+            <UButton
+              icon="i-lucide-sliders-horizontal"
+              color="neutral"
+              variant="outline"
+              :aria-label="$t('common.filters.toggle')"
+              :aria-expanded="filtersOpen"
+              @click="filtersOpen = true"
+            />
+          </UChip>
+        </div>
 
-      <!-- Active filter chips (dismissible) -->
-      <div
-        v-if="activeFilters.length"
-        class="flex items-center gap-2 overflow-x-auto pb-1 -mx-1 px-1"
-      >
-        <UButton
-          v-for="f in activeFilters"
-          :key="f.key"
-          :label="f.label"
-          size="xs"
-          color="primary"
-          variant="soft"
-          trailing-icon="i-lucide-x"
-          class="rounded-full shrink-0"
-          :aria-label="`${$t('common.filters.removeFilter')}: ${f.label}`"
-          @click="f.clear()"
-        />
-        <UButton
-          :label="$t('common.filters.clearAll')"
-          size="xs"
-          color="neutral"
-          variant="ghost"
-          class="shrink-0"
-          @click="emit('clear-all')"
-        />
+        <!-- Active filter chips (dismissible) -->
+        <div
+          v-if="activeFilters.length"
+          class="flex items-center gap-2 overflow-x-auto pb-1 -mx-1 px-1"
+        >
+          <UButton
+            v-for="f in activeFilters"
+            :key="f.key"
+            :label="f.label"
+            size="xs"
+            color="primary"
+            variant="soft"
+            trailing-icon="i-lucide-x"
+            class="rounded-full shrink-0"
+            :aria-label="`${$t('common.filters.removeFilter')}: ${f.label}`"
+            @click="f.clear()"
+          />
+          <UButton
+            :label="$t('common.filters.clearAll')"
+            size="xs"
+            color="neutral"
+            variant="ghost"
+            class="shrink-0"
+            @click="emit('clear-all')"
+          />
+        </div>
       </div>
-    </div>
+    </Teleport>
 
     <!-- Filter drawer (bottom sheet) -->
     <UDrawer v-model:open="filtersOpen" :title="$t('common.filters.toggle')">
@@ -115,6 +114,7 @@ const filtersOpen = ref(false)
 usePageHeader(() => ({
   backTo: props.backTo,
   icon: props.icon,
-  title: props.title
+  title: props.title,
+  hasSearch: true
 }))
 </script>

--- a/Homassy.Web/app/components/ProfileIdentityCard.vue
+++ b/Homassy.Web/app/components/ProfileIdentityCard.vue
@@ -12,7 +12,7 @@
       v-else
       type="button"
       class="w-full flex items-center gap-4 px-4 py-4 text-left transition-colors active:bg-elevated hover:bg-elevated/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500/50"
-      @click="emit('select')"
+      @click="onSelect"
     >
       <div class="border-2 border-primary-500 rounded-full p-0.5 shrink-0">
         <UAvatar
@@ -56,4 +56,12 @@ withDefaults(defineProps<{
 })
 
 const emit = defineEmits<{ select: [] }>()
+
+// Drop focus before the parent opens the edit-profile drawer, so the trigger
+// isn't left focused inside the aria-hidden app root (browser a11y warning).
+function onSelect(event: MouseEvent) {
+  const el = event.currentTarget as HTMLElement | null
+  el?.blur()
+  emit('select')
+}
 </script>

--- a/Homassy.Web/app/components/SettingsRow.vue
+++ b/Homassy.Web/app/components/SettingsRow.vue
@@ -96,6 +96,12 @@ function onClick(event: MouseEvent) {
     event.preventDefault()
     return
   }
+  // Drop focus before the parent opens an overlay: an open drawer/modal marks the
+  // app root aria-hidden, and a still-focused trigger inside it trips the browser's
+  // "aria-hidden on a focused ancestor" warning (and blocks the background from
+  // being hidden from assistive tech). The overlay manages its own focus.
+  const el = event.currentTarget as HTMLElement | null
+  el?.blur()
   emit('select')
 }
 </script>

--- a/Homassy.Web/app/composables/usePageHeader.ts
+++ b/Homassy.Web/app/composables/usePageHeader.ts
@@ -1,0 +1,74 @@
+import { ref, watchEffect, onScopeDispose } from 'vue'
+import { useRoute } from 'vue-router'
+
+export interface PageHeaderConfig {
+  /** Main title. Leave empty/undefined while loading — the header shows a skeleton. */
+  title?: string
+  /** Optional secondary line under the title. */
+  subtitle?: string
+  /** Optional colour dot rendered before the subtitle (e.g. the active shopping list colour). */
+  subtitleColor?: string
+  /** Optional icon rendered after the subtitle (e.g. `i-lucide-users` for a shared list). */
+  subtitleIcon?: string
+  /** Leading icon shown before the title. */
+  icon?: string
+  /** When set, the header shows a back arrow navigating to this route. */
+  backTo?: string
+  /** When set, the header shows an info popover with this text next to the title. */
+  info?: string
+  /** Force the skeleton even after the header is committed (async title/subtitle). */
+  loading?: boolean
+  /** Reserve the subtitle line (so its skeleton shows while the subtitle loads). */
+  hasSubtitle?: boolean
+}
+
+interface HeaderState extends PageHeaderConfig {
+  /** Route path this header was registered for. The layout shows a skeleton while
+   *  this differs from the current route (i.e. during navigation, before the
+   *  incoming page has registered its own header). */
+  path?: string
+}
+
+// Shared, module-scoped state — the auth layout's AppHeader reads it, pages write it.
+// Mirrors useFabActions.ts.
+const header = ref<HeaderState>({})
+const ownerId = ref(0)
+let counter = 0
+
+/**
+ * Read the current page-header state. Used by the auth layout's AppHeader.
+ */
+export const usePageHeaderState = () => header
+
+/**
+ * Register the header (icon + title + subtitle …) for the current page. The
+ * provider is reactive: it is re-evaluated whenever its dependencies (the i18n
+ * locale, a loaded entity, …) change, and the header is cleared automatically
+ * when the page is unmounted.
+ *
+ * The current route path is stamped onto the state (captured once at setup, so
+ * the outgoing page does NOT re-stamp it during navigation). The layout renders
+ * a skeleton whenever the stamped path differs from the live route — giving the
+ * "skeleton, then load" effect across the `out-in` page transition — and while a
+ * field is still empty or `loading` is set.
+ */
+export const usePageHeader = (provider: () => PageHeaderConfig) => {
+  const route = useRoute()
+  // Snapshot the path at setup (non-reactive read): the incoming page stamps its
+  // own path once; the outgoing page keeps its old path so the skeleton shows.
+  const path = route.path
+  const id = ++counter
+
+  watchEffect(() => {
+    header.value = { ...provider(), path }
+    ownerId.value = id
+  })
+
+  onScopeDispose(() => {
+    // Only clear if we are still the owner — avoids wiping the next page's header
+    // when navigation mounts it before this page is disposed.
+    if (ownerId.value === id) {
+      header.value = {}
+    }
+  })
+}

--- a/Homassy.Web/app/composables/usePageHeader.ts
+++ b/Homassy.Web/app/composables/usePageHeader.ts
@@ -20,6 +20,8 @@ export interface PageHeaderConfig {
   loading?: boolean
   /** Reserve the subtitle line (so its skeleton shows while the subtitle loads). */
   hasSubtitle?: boolean
+  /** The page teleports a search bar into the header; reserve + skeleton its row. */
+  hasSearch?: boolean
 }
 
 interface HeaderState extends PageHeaderConfig {

--- a/Homassy.Web/app/layouts/auth.vue
+++ b/Homassy.Web/app/layouts/auth.vue
@@ -4,7 +4,7 @@
       <slot />
     </UMain>
 
-    <nav class="fixed inset-x-4 bottom-4 z-50">
+    <nav class="fixed inset-x-4 bottom-4 z-50 max-w-2xl mx-auto">
       <!-- Dynamic add button, centred on the nav's top border -->
       <NavFab />
 

--- a/Homassy.Web/app/layouts/auth.vue
+++ b/Homassy.Web/app/layouts/auth.vue
@@ -1,6 +1,13 @@
 ﻿<template>
   <UApp class="flex flex-col min-h-screen">
-    <UMain class="flex-1 px-4 sm:px-6 lg:px-8 pb-32">
+    <!-- Persistent page header — lives here (a sibling of the page slot) so it
+         stays mounted across navigation, exactly like the bottom nav below. -->
+    <AppHeader />
+
+    <UMain
+      class="flex-1 px-4 sm:px-6 lg:px-8 pb-32"
+      :style="{ paddingTop: 'calc(var(--app-header-height, 5.5rem) + 1rem)' }"
+    >
       <slot />
     </UMain>
 

--- a/Homassy.Web/app/pages/calendar.vue
+++ b/Homassy.Web/app/pages/calendar.vue
@@ -1,15 +1,5 @@
 <template>
-  <div class="flex flex-col h-[calc(100dvh-8rem)] overflow-hidden lg:block lg:h-auto lg:overflow-visible lg:pb-4">
-    <!-- Page header (capped with a divider; pinned on desktop, always visible on mobile) -->
-    <div class="mb-4 pt-4 pb-3 shrink-0 border-b border-gray-200 dark:border-gray-800 lg:sticky lg:top-0 lg:z-20 lg:bg-white lg:dark:bg-gray-900">
-      <div class="flex items-center gap-3">
-        <UIcon name="i-lucide-calendar" class="h-7 w-7 text-primary-500 shrink-0" />
-        <div>
-          <h1 class="text-xl font-semibold">{{ t('pages.calendar.greeting', { name: greetingName }) }}</h1>
-        </div>
-      </div>
-    </div>
-
+  <div class="flex flex-col h-[calc(100dvh-var(--app-header-height)-1rem-8rem)] overflow-hidden lg:block lg:h-auto lg:overflow-visible lg:pb-4">
     <!-- Desktop: 2-column (calendar left, events right); Mobile: stacked -->
     <div class="flex flex-1 flex-col min-h-0 lg:flex-none lg:grid lg:grid-cols-2 lg:gap-4 lg:items-start">
 
@@ -203,6 +193,13 @@ const { getExternalCalendars } = useExternalCalendarApi()
 const authStore = useAuthStore()
 
 const greetingName = computed(() => authStore.user?.displayName || authStore.user?.name || '')
+
+// Persistent header (auth layout) — greeting is async (waits for the user to load).
+usePageHeader(() => ({
+  icon: 'i-lucide-calendar',
+  title: authStore.user ? t('pages.calendar.greeting', { name: greetingName.value }) : undefined,
+  loading: !authStore.user
+}))
 
 interface CalEvent {
   publicId: string

--- a/Homassy.Web/app/pages/products/[publicId].vue
+++ b/Homassy.Web/app/pages/products/[publicId].vue
@@ -17,9 +17,17 @@ definePageMeta({
 
 const route = useRoute()
 const router = useRouter()
+const { t } = useI18n()
 
 const productPublicId = ref<string | null>((route.params.publicId as string) || null)
 const isOpen = ref(false)
+
+// This route only opens the product drawer over the grid; mirror the products
+// page identity so the persistent header doesn't skeleton behind the drawer.
+usePageHeader(() => ({
+  icon: 'i-lucide-package',
+  title: t('pages.products.title')
+}))
 
 // Open the overview drawer once mounted (the drawer loads on the closed→open transition).
 onMounted(() => {

--- a/Homassy.Web/app/pages/products/index.vue
+++ b/Homassy.Web/app/pages/products/index.vue
@@ -1,10 +1,8 @@
 ﻿<template>
   <div>
-    <!-- Sticky search + filters sub-bar (page identity lives in the persistent AppHeader) -->
-    <div
-      class="sticky z-30 -mx-4 sm:-mx-6 lg:-mx-8 px-6 sm:px-10 lg:px-16 py-3 mb-4 border-b border-gray-200 dark:border-gray-800 bg-default/95 backdrop-blur"
-      :style="{ top: 'var(--app-header-height, 5.5rem)' }"
-    >
+    <!-- Search + filters bar, teleported into the persistent AppHeader (which
+         renders a skeleton in this slot while it is stale/loading). -->
+    <Teleport to="#app-header-search">
       <!-- Search row (always visible) + filters trigger -->
       <div class="space-y-2">
         <div class="flex gap-2">
@@ -70,7 +68,7 @@
           />
         </div>
       </div>
-    </div>
+    </Teleport>
 
     <!-- Filter drawer (bottom sheet) -->
     <UDrawer v-model:open="filtersOpen" :title="$t('pages.products.filters.toggle')">
@@ -245,7 +243,8 @@ const eventBus = useEventBus()
 usePageHeader(() => ({
   icon: 'i-lucide-package',
   title: $t('pages.products.title'),
-  info: $t('pages.products.description')
+  info: $t('pages.products.description'),
+  hasSearch: true
 }))
 
 // The add-inventory wizard (bottom-sheet) opened from the nav FAB.

--- a/Homassy.Web/app/pages/products/index.vue
+++ b/Homassy.Web/app/pages/products/index.vue
@@ -1,30 +1,10 @@
 ﻿<template>
   <div>
-    <!-- Sticky Header with Search -->
-    <div ref="headerRef" class="fixed top-0 left-0 right-0 z-10 bg-white dark:bg-gray-900 px-6 sm:px-10 lg:px-16 py-6 border-b border-gray-200 dark:border-gray-800 space-y-3">
-      <div class="flex items-center gap-3">
-        <UIcon name="i-lucide-package" class="h-7 w-7 text-primary-500 shrink-0" />
-        <div class="min-w-0">
-          <div class="flex items-center gap-1.5">
-            <h1 class="text-2xl font-semibold leading-tight">{{ $t('pages.products.title') }}</h1>
-            <UPopover>
-              <UButton
-                icon="i-lucide-info"
-                color="neutral"
-                variant="ghost"
-                size="xs"
-                :aria-label="$t('pages.products.infoAriaLabel')"
-              />
-              <template #content>
-                <p class="p-3 max-w-xs text-sm text-gray-600 dark:text-gray-400">
-                  {{ $t('pages.products.description') }}
-                </p>
-              </template>
-            </UPopover>
-          </div>
-        </div>
-      </div>
-
+    <!-- Sticky search + filters sub-bar (page identity lives in the persistent AppHeader) -->
+    <div
+      class="sticky z-30 -mx-4 sm:-mx-6 lg:-mx-8 px-6 sm:px-10 lg:px-16 py-3 mb-4 border-b border-gray-200 dark:border-gray-800 bg-default/95 backdrop-blur"
+      :style="{ top: 'var(--app-header-height, 5.5rem)' }"
+    >
       <!-- Search row (always visible) + filters trigger -->
       <div class="space-y-2">
         <div class="flex gap-2">
@@ -182,8 +162,8 @@
       </template>
     </UDrawer>
 
-    <!-- Content Section (offset by the fixed header's measured height) -->
-    <div class="px-4 sm:px-8 lg:px-14 pb-6" :style="{ paddingTop: headerHeight ? `calc(${headerHeight}px + 1.5rem)` : '15rem' }">
+    <!-- Content Section -->
+    <div class="px-4 sm:px-8 lg:px-14 pb-6">
 
     <PullToRefreshIndicator
       :pull-distance="pullDistance"
@@ -261,6 +241,13 @@ const { showCameraButton } = useCameraAvailability()
 const inventorySocket = useInventorySocket()
 const eventBus = useEventBus()
 
+// Persistent header (auth layout) — page identity + info popover.
+usePageHeader(() => ({
+  icon: 'i-lucide-package',
+  title: $t('pages.products.title'),
+  info: $t('pages.products.description')
+}))
+
 // The add-inventory wizard (bottom-sheet) opened from the nav FAB.
 const isAddInventoryOpen = ref(false)
 
@@ -307,15 +294,6 @@ const pageSize = 20
 const loadingMore = ref(false)
 const sentinelRef = ref<HTMLElement | null>(null)
 const observer = ref<IntersectionObserver | null>(null)
-
-// Fixed header: measure its (variable) height so the scrollable content can be offset by it.
-const headerRef = ref<HTMLElement | null>(null)
-const headerHeight = ref(0)
-let headerObserver: ResizeObserver | null = null
-
-const updateHeaderHeight = () => {
-  if (headerRef.value) headerHeight.value = headerRef.value.offsetHeight
-}
 
 // Filter dropdown options
 const expirationOptions = computed(() => [
@@ -744,13 +722,6 @@ onMounted(() => {
   inventorySocket.on('ProductFavoriteChanged', handleRealtimeProductFavoriteChanged)
   inventorySocket.on('ProductDeleted', handleRealtimeProductDeleted)
   inventorySocket.onReconnected(loadProducts)
-
-  // Track the fixed header's height (changes when the filter chips row appears/disappears).
-  updateHeaderHeight()
-  if (headerRef.value && typeof ResizeObserver !== 'undefined') {
-    headerObserver = new ResizeObserver(() => updateHeaderHeight())
-    headerObserver.observe(headerRef.value)
-  }
 })
 
 // Cleanup on unmount
@@ -764,10 +735,6 @@ onBeforeUnmount(() => {
 
   if (observer.value) {
     observer.value.disconnect()
-  }
-  if (headerObserver) {
-    headerObserver.disconnect()
-    headerObserver = null
   }
 })
 </script>

--- a/Homassy.Web/app/pages/profile/automation/[publicId].vue
+++ b/Homassy.Web/app/pages/profile/automation/[publicId].vue
@@ -1,45 +1,35 @@
 ﻿<template>
   <div>
-    <!-- Fixed Header -->
-    <div class="fixed top-0 left-0 right-0 z-10 bg-white dark:bg-gray-900 px-6 sm:px-10 lg:px-16 py-6 border-b border-gray-200 dark:border-gray-800">
-      <div class="flex items-center justify-between gap-3">
-        <div class="flex items-center gap-3 min-w-0 flex-1">
-          <NuxtLink to="/profile/automation">
-            <UButton
-              icon="i-lucide-arrow-left"
-              color="neutral"
-              variant="ghost"
-            />
-          </NuxtLink>
-        </div>
-        <div v-if="automation" class="flex items-center gap-2 flex-shrink-0">
-          <USwitch
-            :model-value="automation.isEnabled"
-            :disabled="isToggling"
-            :loading="isToggling"
-            size="sm"
-            @update:model-value="toggleEnabled"
-          />
-          <UButton
-            icon="i-lucide-pencil"
-            color="neutral"
-            variant="ghost"
-            size="sm"
-            @click="openEditModal"
-          />
-          <UButton
-            icon="i-lucide-trash-2"
-            color="error"
-            variant="ghost"
-            size="sm"
-            @click="confirmDelete"
-          />
-        </div>
-      </div>
-    </div>
+    <!-- Enable/edit/delete actions live in the persistent AppHeader (teleported);
+         back + product identity come from usePageHeader (script). -->
+    <Teleport to="#app-header-actions">
+      <template v-if="automation">
+        <USwitch
+          :model-value="automation.isEnabled"
+          :disabled="isToggling"
+          :loading="isToggling"
+          size="sm"
+          @update:model-value="toggleEnabled"
+        />
+        <UButton
+          icon="i-lucide-pencil"
+          color="neutral"
+          variant="ghost"
+          size="sm"
+          @click="openEditModal"
+        />
+        <UButton
+          icon="i-lucide-trash-2"
+          color="error"
+          variant="ghost"
+          size="sm"
+          @click="confirmDelete"
+        />
+      </template>
+    </Teleport>
 
     <!-- Content -->
-    <div class="pt-28 px-4 sm:px-8 lg:px-14 pb-6">
+    <div class="px-4 sm:px-8 lg:px-14 pb-6">
       <!-- Loading State -->
       <div v-if="isLoading" class="space-y-6">
         <USkeleton class="h-64 w-full rounded-xl" />
@@ -58,22 +48,6 @@
       <div v-else-if="automation" class="space-y-6">
         <!-- Details Card -->
         <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-5 space-y-4">
-          <!-- Product Info -->
-          <div class="flex items-center gap-3">
-            <div
-              class="flex-shrink-0 w-12 h-12 rounded-xl flex items-center justify-center"
-              :class="actionTypeIconBg"
-            >
-              <UIcon :name="actionTypeIconName" class="h-6 w-6 text-white" />
-            </div>
-            <div class="min-w-0 flex-1">
-              <h2 class="text-lg font-bold text-gray-900 dark:text-white truncate">{{ automation.productName }}</h2>
-              <p v-if="automation.productBrand" class="text-sm text-gray-500 dark:text-gray-400">{{ automation.productBrand }}</p>
-            </div>
-          </div>
-
-          <div class="border-t border-gray-100 dark:border-gray-700" />
-
           <!-- Action Type -->
           <div class="flex items-center gap-2">
             <span
@@ -533,15 +507,16 @@ const actionTypeIconName = computed(() => {
   }
 })
 
-const actionTypeIconBg = computed(() => {
-  switch (automation.value?.actionType) {
-    case AutomationActionType.AutoConsume: return 'bg-blue-500'
-    case AutomationActionType.NotifyOnly: return 'bg-amber-500'
-    case AutomationActionType.AddToShoppingList: return 'bg-green-500'
-    case AutomationActionType.LowStockAddToShoppingList: return 'bg-red-500'
-    default: return 'bg-gray-500'
-  }
-})
+// Persistent header (auth layout) — the rule's product identity (async); the
+// enable/edit/delete actions are teleported into the header from the template.
+usePageHeader(() => ({
+  backTo: '/profile/automation',
+  icon: actionTypeIconName.value,
+  title: automation.value?.productName,
+  subtitle: automation.value?.productBrand,
+  hasSubtitle: !!automation.value?.productBrand,
+  loading: isLoading.value
+}))
 
 const actionTypeBadgeClass = computed(() => {
   switch (automation.value?.actionType) {

--- a/Homassy.Web/app/pages/profile/automation/create.vue
+++ b/Homassy.Web/app/pages/profile/automation/create.vue
@@ -1,20 +1,10 @@
 ﻿<template>
   <div>
-    <!-- Fixed Header -->
-    <div class="fixed top-0 left-0 right-0 z-10 bg-white dark:bg-gray-900 px-6 sm:px-10 lg:px-16 py-6 space-y-4">
-      <div class="flex items-center gap-3">
-        <NuxtLink to="/profile/automation">
-          <UButton
-            icon="i-lucide-arrow-left"
-            color="neutral"
-            variant="ghost"
-          />
-        </NuxtLink>
-        <UIcon name="i-lucide-timer" class="h-7 w-7 text-primary-500" />
-        <h1 class="text-2xl font-semibold">{{ t('profile.automation.createAutomation') }}</h1>
-      </div>
-
-      <!-- Stepper -->
+    <!-- Sticky stepper sub-bar (page identity lives in the persistent AppHeader) -->
+    <div
+      class="sticky z-30 -mx-4 sm:-mx-6 lg:-mx-8 px-6 sm:px-10 lg:px-16 py-3 mb-4 border-b border-gray-200 dark:border-gray-800 bg-default/95 backdrop-blur"
+      :style="{ top: 'var(--app-header-height, 5.5rem)' }"
+    >
       <UStepper
         :model-value="currentStep"
         :items="stepperItems"
@@ -23,8 +13,8 @@
       />
     </div>
 
-    <!-- Content Section with padding to account for fixed header -->
-    <div class="pt-48 px-4 sm:px-8 lg:px-14 pb-6">
+    <!-- Content Section -->
+    <div class="px-4 sm:px-8 lg:px-14 pb-6">
 
       <!-- Step 1: Action Type -->
       <div v-if="currentStep === 0" class="space-y-6">
@@ -476,6 +466,13 @@ const { getShoppingLists } = useShoppingListApi()
 const { t } = useI18n()
 const toast = useToast()
 const { showCameraButton } = useCameraAvailability()
+
+// Persistent header (auth layout) — back + identity (the stepper stays in-page).
+usePageHeader(() => ({
+  backTo: '/profile/automation',
+  icon: 'i-lucide-timer',
+  title: t('profile.automation.createAutomation')
+}))
 
 // Stepper state
 const currentStep = ref(0)

--- a/Homassy.Web/app/pages/profile/create-family.vue
+++ b/Homassy.Web/app/pages/profile/create-family.vue
@@ -1,20 +1,5 @@
 ﻿<template>
   <div class="px-4 sm:px-6 lg:px-8 py-6 space-y-6">
-    <!-- Header with back button -->
-    <div class="flex items-center gap-3">
-      <NuxtLink to="/profile">
-        <UButton
-          icon="i-lucide-arrow-left"
-          color="neutral"
-          variant="ghost"
-        />
-      </NuxtLink>
-      <UIcon name="i-lucide-users" class="text-xl text-primary" />
-      <div>
-        <h1 class="text-2xl font-semibold">{{ $t('profile.family.create') }}</h1>
-      </div>
-    </div>
-
     <!-- Create Family Form -->
     <UForm @submit.prevent="onSubmit" class="space-y-4">
       <div>
@@ -40,15 +25,24 @@
 </template>
 
 <script setup lang="ts">
-definePageMeta({ layout: 'auth', middleware: 'auth' })
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useFamilyApi } from '~/composables/api/useFamilyApi'
+
+definePageMeta({ layout: 'auth', middleware: 'auth' })
 
 const name = ref('')
 const description = ref('')
 const { createFamily } = useFamilyApi()
 const router = useRouter()
+const { t } = useI18n()
+
+// Persistent header (auth layout) — back + identity.
+usePageHeader(() => ({
+  backTo: '/profile',
+  icon: 'i-lucide-users',
+  title: t('profile.family.create')
+}))
 
 async function onSubmit() {
   await createFamily({ name: name.value, description: description.value })

--- a/Homassy.Web/app/pages/profile/data.vue
+++ b/Homassy.Web/app/pages/profile/data.vue
@@ -1,14 +1,5 @@
 <template>
   <div class="px-4 sm:px-6 lg:px-8 py-6 space-y-6 max-w-2xl mx-auto">
-    <!-- Header with back button -->
-    <div class="flex items-center gap-3">
-      <NuxtLink to="/profile">
-        <UButton icon="i-lucide-arrow-left" color="neutral" variant="ghost" />
-      </NuxtLink>
-      <UIcon name="i-lucide-database" class="text-xl text-primary" />
-      <h1 class="text-2xl font-semibold">{{ $t('profile.masterData.title') }}</h1>
-    </div>
-
     <SettingsGroup :hint="$t('profile.masterData.description')">
       <SettingsRow
         :label="$t('profile.allProducts.title')"
@@ -46,4 +37,13 @@
 
 <script setup lang="ts">
 definePageMeta({ layout: 'auth', middleware: 'auth' })
+
+const { t } = useI18n()
+
+// Persistent header (auth layout) — back + identity.
+usePageHeader(() => ({
+  backTo: '/profile',
+  icon: 'i-lucide-database',
+  title: t('profile.masterData.title')
+}))
 </script>

--- a/Homassy.Web/app/pages/profile/external-calendars.vue
+++ b/Homassy.Web/app/pages/profile/external-calendars.vue
@@ -1,14 +1,5 @@
 <template>
   <div class="px-4 sm:px-6 lg:px-8 py-6 space-y-6 max-w-2xl mx-auto">
-    <!-- Header with back button -->
-    <div class="flex items-center gap-3">
-      <NuxtLink to="/profile/data">
-        <UButton icon="i-lucide-arrow-left" color="neutral" variant="ghost" />
-      </NuxtLink>
-      <UIcon name="i-lucide-calendar-plus" class="text-xl text-primary" />
-      <h1 class="text-2xl font-semibold">{{ $t('profile.family.externalCalendars.title') }}</h1>
-    </div>
-
     <template v-if="loading">
       <USkeleton class="h-4 w-2/3 rounded mb-4" />
       <USkeleton class="h-20 w-full rounded-lg mb-3" />
@@ -148,6 +139,13 @@ const {
 } = useExternalCalendarApi()
 const { t: $t } = useI18n()
 const toast = useToast()
+
+// Persistent header (auth layout) — back + identity.
+usePageHeader(() => ({
+  backTo: '/profile/data',
+  icon: 'i-lucide-calendar-plus',
+  title: $t('profile.family.externalCalendars.title')
+}))
 
 const loading = ref(true)
 const hasFamily = ref(false)

--- a/Homassy.Web/app/pages/profile/index.vue
+++ b/Homassy.Web/app/pages/profile/index.vue
@@ -1,15 +1,7 @@
 <template>
   <div>
-    <!-- Fixed Header -->
-    <div class="fixed top-0 left-0 right-0 z-10 bg-white dark:bg-gray-900 px-6 sm:px-10 lg:px-16 py-6">
-      <div class="flex items-center gap-3">
-        <UIcon name="i-lucide-user" class="h-7 w-7 text-primary-500" />
-        <h1 class="text-2xl font-semibold">{{ $t('profile.title') }}</h1>
-      </div>
-    </div>
-
-    <!-- Content Section with padding to account for fixed header -->
-    <div class="pt-28 px-4 sm:px-8 lg:px-14 pb-6 space-y-6 max-w-2xl mx-auto">
+    <!-- Content Section (page identity lives in the persistent AppHeader) -->
+    <div class="px-4 sm:px-8 lg:px-14 pb-6 space-y-6 max-w-2xl mx-auto">
       <!-- Identity card: avatar + name; tap to open the edit-profile drawer -->
       <ProfileIdentityCard
         :loading="loading"
@@ -246,6 +238,12 @@ const { getVersion } = useVersionApi()
 const { t } = useI18n()
 const colorMode = useColorMode()
 const route = useRoute()
+
+// Persistent header (auth layout) — page identity.
+usePageHeader(() => ({
+  icon: 'i-lucide-user',
+  title: t('profile.title')
+}))
 
 const {
   languageSelectOptions,

--- a/Homassy.Web/app/pages/profile/join-family.vue
+++ b/Homassy.Web/app/pages/profile/join-family.vue
@@ -1,20 +1,5 @@
 ﻿<template>
   <div class="px-4 sm:px-6 lg:px-8 py-6 space-y-6">
-    <!-- Header with back button -->
-    <div class="flex items-center gap-3">
-      <NuxtLink to="/profile">
-        <UButton
-          icon="i-lucide-arrow-left"
-          color="neutral"
-          variant="ghost"
-        />
-      </NuxtLink>
-      <UIcon name="i-lucide-users" class="text-xl text-primary" />
-      <div>
-        <h1 class="text-2xl font-semibold">{{ $t('profile.family.join') }}</h1>
-      </div>
-    </div>
-
     <!-- Join Family Form -->
     <UForm @submit.prevent="onSubmit" class="space-y-4">
       <div>
@@ -36,14 +21,23 @@
 </template>
 
 <script setup lang="ts">
-definePageMeta({ layout: 'auth', middleware: 'auth' })
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useFamilyApi } from '~/composables/api/useFamilyApi'
 
+definePageMeta({ layout: 'auth', middleware: 'auth' })
+
 const shareCode = ref('')
 const { requestJoin } = useFamilyApi()
 const router = useRouter()
+const { t } = useI18n()
+
+// Persistent header (auth layout) — back + identity.
+usePageHeader(() => ({
+  backTo: '/profile',
+  icon: 'i-lucide-users',
+  title: t('profile.family.join')
+}))
 
 async function onSubmit() {
   const res = await requestJoin({ shareCode: shareCode.value })

--- a/Homassy.Web/app/pages/shopping-lists/index.vue
+++ b/Homassy.Web/app/pages/shopping-lists/index.vue
@@ -1,90 +1,89 @@
 <template>
   <div>
-    <!-- Sticky search + filters sub-bar (identity + active-list subtitle live in the persistent AppHeader) -->
-    <div
-      class="sticky z-30 -mx-4 sm:-mx-6 lg:-mx-8 px-6 sm:px-10 lg:px-16 py-3 mb-4 space-y-3 border-b border-gray-200 dark:border-gray-800 bg-default/95 backdrop-blur"
-      :style="{ top: 'var(--app-header-height, 5.5rem)' }"
-    >
-
-      <!-- Search row + filters trigger -->
-      <div class="flex gap-2">
-        <UFieldGroup size="md" orientation="horizontal" class="flex-1">
-          <UInput
-            v-model="searchQuery"
-            :disabled="!isSearchEnabled"
-            :placeholder="$t('pages.shoppingLists.searchPlaceholder')"
-            class="flex-1"
-          >
-            <template #trailing>
-              <UButton
-                v-if="searchQuery"
-                icon="i-lucide-x"
-                size="xs"
-                color="neutral"
-                variant="ghost"
-                :disabled="!isSearchEnabled"
-                @click="searchQuery = ''"
-              />
-            </template>
-          </UInput>
-          <BarcodeScannerButton
-            v-if="showCameraButton"
-            :disabled="!isSearchEnabled"
-            @scanned="handleBarcodeScanned"
-          />
-        </UFieldGroup>
-        <UButton
-          v-if="listLocations.length > 0"
-          :icon="locationTracking ? 'i-lucide-navigation' : 'i-lucide-navigation-off'"
-          :color="locationTracking ? 'primary' : 'neutral'"
-          :variant="locationTracking ? 'solid' : 'outline'"
-          size="md"
-          :loading="isLocating"
-          :aria-label="$t('pages.shoppingLists.nearby.toggle')"
-          :aria-pressed="locationTracking"
-          @click="toggleLocation"
-        />
-        <UChip :show="activeFilterCount > 0" :text="activeFilterCount" color="primary" size="2xl">
+    <!-- Search + filters bar, teleported into the persistent AppHeader (identity +
+         active-list subtitle live there too; the header skeletons this slot). -->
+    <Teleport to="#app-header-search">
+      <div class="space-y-3">
+        <!-- Search row + filters trigger -->
+        <div class="flex gap-2">
+          <UFieldGroup size="md" orientation="horizontal" class="flex-1">
+            <UInput
+              v-model="searchQuery"
+              :disabled="!isSearchEnabled"
+              :placeholder="$t('pages.shoppingLists.searchPlaceholder')"
+              class="flex-1"
+            >
+              <template #trailing>
+                <UButton
+                  v-if="searchQuery"
+                  icon="i-lucide-x"
+                  size="xs"
+                  color="neutral"
+                  variant="ghost"
+                  :disabled="!isSearchEnabled"
+                  @click="searchQuery = ''"
+                />
+              </template>
+            </UInput>
+            <BarcodeScannerButton
+              v-if="showCameraButton"
+              :disabled="!isSearchEnabled"
+              @scanned="handleBarcodeScanned"
+            />
+          </UFieldGroup>
           <UButton
-            icon="i-lucide-sliders-horizontal"
-            color="primary"
+            v-if="listLocations.length > 0"
+            :icon="locationTracking ? 'i-lucide-navigation' : 'i-lucide-navigation-off'"
+            :color="locationTracking ? 'primary' : 'neutral'"
+            :variant="locationTracking ? 'solid' : 'outline'"
             size="md"
-            :aria-label="$t('pages.shoppingLists.filters.toggle')"
-            :aria-expanded="filtersOpen"
-            @click="filtersOpen = true"
-          >
-            <span class="hidden sm:inline">{{ $t('pages.shoppingLists.filters.toggle') }}</span>
-          </UButton>
-        </UChip>
-      </div>
+            :loading="isLocating"
+            :aria-label="$t('pages.shoppingLists.nearby.toggle')"
+            :aria-pressed="locationTracking"
+            @click="toggleLocation"
+          />
+          <UChip :show="activeFilterCount > 0" :text="activeFilterCount" color="primary" size="2xl">
+            <UButton
+              icon="i-lucide-sliders-horizontal"
+              color="primary"
+              size="md"
+              :aria-label="$t('pages.shoppingLists.filters.toggle')"
+              :aria-expanded="filtersOpen"
+              @click="filtersOpen = true"
+            >
+              <span class="hidden sm:inline">{{ $t('pages.shoppingLists.filters.toggle') }}</span>
+            </UButton>
+          </UChip>
+        </div>
 
-      <!-- Active filter chips (dismissible) -->
-      <div
-        v-if="activeFilters.length"
-        class="flex items-center gap-2 overflow-x-auto pb-1 -mx-1 px-1"
-      >
-        <UButton
-          v-for="f in activeFilters"
-          :key="f.key"
-          :label="f.label"
-          size="xs"
-          color="primary"
-          variant="soft"
-          trailing-icon="i-lucide-x"
-          class="rounded-full shrink-0"
-          :aria-label="`${$t('pages.shoppingLists.filters.removeFilter')}: ${f.label}`"
-          @click="f.clear()"
-        />
-        <UButton
-          :label="$t('pages.shoppingLists.filters.clearAll')"
-          size="xs"
-          color="neutral"
-          variant="ghost"
-          class="shrink-0"
-          @click="clearAllFilters"
-        />
+        <!-- Active filter chips (dismissible) -->
+        <div
+          v-if="activeFilters.length"
+          class="flex items-center gap-2 overflow-x-auto pb-1 -mx-1 px-1"
+        >
+          <UButton
+            v-for="f in activeFilters"
+            :key="f.key"
+            :label="f.label"
+            size="xs"
+            color="primary"
+            variant="soft"
+            trailing-icon="i-lucide-x"
+            class="rounded-full shrink-0"
+            :aria-label="`${$t('pages.shoppingLists.filters.removeFilter')}: ${f.label}`"
+            @click="f.clear()"
+          />
+          <UButton
+            :label="$t('pages.shoppingLists.filters.clearAll')"
+            size="xs"
+            color="neutral"
+            variant="ghost"
+            class="shrink-0"
+            @click="clearAllFilters"
+          />
+        </div>
       </div>
-    </div>
+    </Teleport>
 
     <!-- Content Section -->
     <div class="px-2 sm:px-4 md:px-6 lg:px-8 pb-6">
@@ -630,7 +629,8 @@ usePageHeader(() => ({
   subtitle: currentListDetails.value?.name,
   subtitleColor: currentListDetails.value?.color || undefined,
   subtitleIcon: currentListDetails.value?.isSharedWithFamily ? 'i-lucide-users' : undefined,
-  hasSubtitle: isLoadingDetails.value || !!currentListDetails.value
+  hasSubtitle: isLoadingDetails.value || !!currentListDetails.value,
+  hasSearch: true
 }))
 
 // Create modal state

--- a/Homassy.Web/app/pages/shopping-lists/index.vue
+++ b/Homassy.Web/app/pages/shopping-lists/index.vue
@@ -1,46 +1,10 @@
 <template>
   <div>
-    <!-- Fixed Header -->
-    <div ref="headerRef" class="fixed top-0 left-0 right-0 z-10 bg-white dark:bg-gray-900 px-6 sm:px-10 lg:px-16 py-6 border-b border-gray-200 dark:border-gray-800 space-y-3">
-      <!-- Title Row + active list subtitle -->
-      <div class="flex items-center gap-3">
-        <UIcon name="i-lucide-shopping-cart" class="h-7 w-7 text-primary-500 shrink-0" />
-        <div class="min-w-0">
-          <div class="flex items-center gap-1.5">
-            <h1 class="text-2xl font-semibold leading-tight">{{ $t('pages.shoppingLists.title') }}</h1>
-            <UPopover>
-              <UButton
-                icon="i-lucide-info"
-                color="neutral"
-                variant="ghost"
-                size="xs"
-                :aria-label="$t('pages.shoppingLists.infoAriaLabel')"
-              />
-              <template #content>
-                <p class="p-3 max-w-xs text-sm text-gray-600 dark:text-gray-400">
-                  {{ $t('pages.shoppingLists.description') }}
-                </p>
-              </template>
-            </UPopover>
-          </div>
-          <div
-            v-if="currentListDetails"
-            class="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400"
-          >
-            <span
-              v-if="currentListDetails.color"
-              class="w-2.5 h-2.5 rounded-full shrink-0"
-              :style="{ backgroundColor: currentListDetails.color }"
-            />
-            <span class="truncate">{{ currentListDetails.name }}</span>
-            <UIcon
-              v-if="currentListDetails.isSharedWithFamily"
-              name="i-lucide-users"
-              class="h-3.5 w-3.5 text-primary-500 shrink-0"
-            />
-          </div>
-        </div>
-      </div>
+    <!-- Sticky search + filters sub-bar (identity + active-list subtitle live in the persistent AppHeader) -->
+    <div
+      class="sticky z-30 -mx-4 sm:-mx-6 lg:-mx-8 px-6 sm:px-10 lg:px-16 py-3 mb-4 space-y-3 border-b border-gray-200 dark:border-gray-800 bg-default/95 backdrop-blur"
+      :style="{ top: 'var(--app-header-height, 5.5rem)' }"
+    >
 
       <!-- Search row + filters trigger -->
       <div class="flex gap-2">
@@ -122,8 +86,8 @@
       </div>
     </div>
 
-    <!-- Content Section (offset by the fixed header's measured height) -->
-    <div class="px-2 sm:px-4 md:px-6 lg:px-8 pb-6" :style="{ paddingTop: headerHeight ? `calc(${headerHeight}px + 1.5rem)` : '16rem' }">
+    <!-- Content Section -->
+    <div class="px-2 sm:px-4 md:px-6 lg:px-8 pb-6">
       <PullToRefreshIndicator
         :pull-distance="pullDistance"
         :is-pulling="isPulling"
@@ -657,14 +621,17 @@ const notifiedLocationIds = ref<Set<string>>(new Set())
 // picker. Only locations with resolvable coordinates participate in proximity.
 const allShoppingLocations = ref<ShoppingLocationInfo[]>([])
 
-// Fixed-header height measurement (offsets the scrollable content)
-const headerRef = ref<HTMLElement | null>(null)
-const headerHeight = ref(0)
-let headerObserver: ResizeObserver | null = null
-
-const updateHeaderHeight = () => {
-  if (headerRef.value) headerHeight.value = headerRef.value.offsetHeight
-}
+// Persistent header (auth layout) — identity + info + the active list's subtitle
+// (name, colour dot, shared icon). The subtitle skeletons while a list loads.
+usePageHeader(() => ({
+  icon: 'i-lucide-shopping-cart',
+  title: $t('pages.shoppingLists.title'),
+  info: $t('pages.shoppingLists.description'),
+  subtitle: currentListDetails.value?.name,
+  subtitleColor: currentListDetails.value?.color || undefined,
+  subtitleIcon: currentListDetails.value?.isSharedWithFamily ? 'i-lucide-users' : undefined,
+  hasSubtitle: isLoadingDetails.value || !!currentListDetails.value
+}))
 
 // Create modal state
 const isCreateModalOpen = ref(false)
@@ -1428,13 +1395,6 @@ onMounted(() => {
 
   loadShoppingLists()
   loadAllShoppingLocations()
-
-  // Track the fixed header's height (changes when subtitle/filter chips appear)
-  updateHeaderHeight()
-  if (headerRef.value && typeof ResizeObserver !== 'undefined') {
-    headerObserver = new ResizeObserver(() => updateHeaderHeight())
-    headerObserver.observe(headerRef.value)
-  }
 })
 
 onBeforeUnmount(() => {
@@ -1449,10 +1409,5 @@ onBeforeUnmount(() => {
 
   // Stop watching the device position when leaving the page.
   stopWatch()
-
-  if (headerObserver) {
-    headerObserver.disconnect()
-    headerObserver = null
-  }
 })
 </script>

--- a/Homassy.Web/i18n/locales/de.json
+++ b/Homassy.Web/i18n/locales/de.json
@@ -57,6 +57,7 @@
     "confirm": "Bestätigen",
     "apply": "Anwenden",
     "back": "Zurück",
+    "info": "Information",
     "family": "Familie",
     "personal": "Persönlich",
     "filters": {

--- a/Homassy.Web/i18n/locales/en.json
+++ b/Homassy.Web/i18n/locales/en.json
@@ -57,6 +57,7 @@
     "website": "Website",
     "apply": "Apply",
     "back": "Back",
+    "info": "Information",
     "family": "Family",
     "personal": "Personal",
     "filters": {

--- a/Homassy.Web/i18n/locales/hu.json
+++ b/Homassy.Web/i18n/locales/hu.json
@@ -57,6 +57,7 @@
     "website": "Weboldal",
     "apply": "Alkalmaz",
     "back": "Vissza",
+    "info": "Információ",
     "family": "Család",
     "personal": "Személyes",
     "filters": {


### PR DESCRIPTION
## Summary

Introduce a single persistent page header (`AppHeader`) in the auth layout that stays mounted across navigation — like the bottom nav — replacing the per-page fixed headers each screen re-implemented. Pages now declare their header (icon, title, subtitle, back link, info) through a new `usePageHeader` composable and teleport their search/filter bars and actions into it.

- Add `AppHeader.vue` + `usePageHeader.ts`: module-scoped header state with skeleton/stale handling across the page transition and SSR/hydration-safe mount gating.
- Publish the measured header height as `--app-header-height`; the layout offsets `UMain` and pages size sticky sub-bars / scroll containers against it.
- Move search, filter chips, and page actions into the header via `Teleport` targets (`#app-header-search`, `#app-header-actions`); drop the duplicated fixed headers and per-page `ResizeObserver` height code from the products, shopping-lists, profile, automation, and calendar pages.
- Center the bottom nav and drawers on desktop (`max-w-2xl mx-auto` + drawer content cap).
- Blur the trigger before opening an overlay in `SettingsRow` / `ProfileIdentityCard` to avoid the aria-hidden-on-focused-ancestor warning.
- Add the `common.info` string (hu/en/de).
