### PR TITLE
feat(pwa): add boot splash screen for standalone launch

### DIFF
--- a/Homassy.Web/app/app.vue
+++ b/Homassy.Web/app/app.vue
@@ -31,7 +31,10 @@ useSeoMeta({
 </script>
 
 <template>
-  <NuxtLayout :toaster="toaster">
-    <NuxtPage />
-  </NuxtLayout>
+  <div>
+    <NuxtLayout :toaster="toaster">
+      <NuxtPage />
+    </NuxtLayout>
+    <SplashScreen />
+  </div>
 </template>

--- a/Homassy.Web/app/components/SplashScreen.vue
+++ b/Homassy.Web/app/components/SplashScreen.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import { useAuthStore } from '~/stores/auth'
+import type { VersionInfo } from '~/types/version'
+
+// Boot splash shown only when running as an installed PWA (standalone display
+// mode — enforced in CSS below). Logo + spinner render server-side so they
+// paint during the pre-hydration auth window; the name/version are client-only
+// (auth + version resolve after hydration) and are wrapped in <ClientOnly> to
+// avoid a hydration mismatch.
+
+const authStore = useAuthStore()
+
+const userName = computed(() => authStore.user?.displayName || authStore.user?.name || '')
+
+// Reuse the exact version source + formatting from the profile page: the value
+// comes from GET /api/Version (backend assembly version), short form in prod.
+const isProduction = import.meta.env.PROD
+const versionInfo = ref<VersionInfo | null>(null)
+const displayVersion = computed(() => {
+  if (!versionInfo.value) return ''
+  return isProduction ? versionInfo.value.shortVersion : versionInfo.value.version
+})
+
+onMounted(async () => {
+  try {
+    const res = await useVersionApi().getVersion()
+    if (res.success && res.data) versionInfo.value = res.data
+  }
+  catch {
+    // Version is best-effort on the splash — ignore failures.
+  }
+})
+</script>
+
+<template>
+  <div class="splash" aria-hidden="true">
+    <div class="splash__inner">
+      <img
+        src="/favicon.svg"
+        alt="Homassy"
+        class="splash__logo"
+        width="88"
+        height="88"
+      >
+
+      <ClientOnly>
+        <p v-if="userName" class="splash__welcome">
+          <span class="splash__welcome-label">{{ $t('splash.welcomeBack') }}</span>
+          <span class="splash__name">{{ userName }}</span>
+        </p>
+      </ClientOnly>
+
+      <div class="splash__spinner" role="status" :aria-label="$t('common.loading')" />
+    </div>
+
+    <ClientOnly>
+      <p v-if="displayVersion" class="splash__version">v{{ displayVersion }}</p>
+    </ClientOnly>
+  </div>
+</template>
+
+<!-- Global (unscoped) so the `.splash` class stays literal for the
+     `:root[data-splash-ready]` dismissal selector and the standalone media query. -->
+<style>
+.splash {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 2147483000;
+  background-color: #c9b8a0;
+  color: #2b2620;
+  transition: opacity 0.3s ease;
+}
+
+/* Only ever visible when launched as an installed PWA. */
+@media all and (display-mode: standalone) {
+  .splash {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+/* Dismissal: stamped on <html> by useSplashScreen().markReady(). */
+:root[data-splash-ready] .splash {
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.splash__inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.25rem;
+  padding: 2rem;
+}
+
+.splash__logo {
+  width: 88px;
+  height: 88px;
+  filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.15));
+}
+
+.splash__welcome {
+  text-align: center;
+  line-height: 1.3;
+}
+
+.splash__welcome-label {
+  display: block;
+  font-size: 0.8rem;
+  opacity: 0.7;
+}
+
+.splash__name {
+  display: block;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.splash__spinner {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 3px solid rgba(43, 38, 32, 0.25);
+  border-top-color: #2b2620;
+  animation: splash-spin 0.8s linear infinite;
+}
+
+.splash__version {
+  position: fixed;
+  bottom: max(1.5rem, env(safe-area-inset-bottom));
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.75rem;
+  opacity: 0.6;
+}
+
+@keyframes splash-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .splash__spinner {
+    animation-duration: 1.6s;
+  }
+}
+</style>

--- a/Homassy.Web/app/composables/useSplashScreen.ts
+++ b/Homassy.Web/app/composables/useSplashScreen.ts
@@ -1,0 +1,21 @@
+/**
+ * Splash screen state.
+ *
+ * The boot splash is shown ONLY in standalone PWA mode — that decision is made
+ * purely in CSS (`@media (display-mode: standalone)`), so the overlay can render
+ * in the SSR HTML and paint on the very first frame without any hydration
+ * mismatch. This composable only handles dismissal: `markReady()` stamps a
+ * `data-splash-ready` attribute on <html>, which CSS uses to fade the overlay
+ * out. Toggling an attribute on the document (instead of a reactive `v-if`)
+ * keeps dismissal completely outside Vue's hydration diff, so it works even
+ * when it fires before the app mounts (e.g. the anonymous fast-path).
+ */
+export function useSplashScreen() {
+  const markReady = () => {
+    if (import.meta.client) {
+      document.documentElement.setAttribute('data-splash-ready', 'true')
+    }
+  }
+
+  return { markReady }
+}

--- a/Homassy.Web/app/pages/calendar.vue
+++ b/Homassy.Web/app/pages/calendar.vue
@@ -191,6 +191,7 @@ const { getCalendarEvents } = useCalendarApi()
 const { getActivities } = useUserApi()
 const { getExternalCalendars } = useExternalCalendarApi()
 const authStore = useAuthStore()
+const { markReady: markSplashReady } = useSplashScreen()
 
 const greetingName = computed(() => authStore.user?.displayName || authStore.user?.name || '')
 
@@ -474,6 +475,9 @@ const loadEvents = async () => {
       externalCalendars.value = calendarsRes.data.filter(c => c.isEnabled)
   } finally {
     isLoading.value = false
+    // Normal PWA relaunch lands here — dismiss the boot splash once the
+    // calendar's first data load has settled.
+    markSplashReady()
   }
 }
 

--- a/Homassy.Web/app/plugins/auth.ts
+++ b/Homassy.Web/app/plugins/auth.ts
@@ -1,11 +1,17 @@
-﻿/**
+/**
  * Auth initialization plugin
  * Checks for existing Kratos session on client startup.
  * Must run client-side only: Kratos session cookies are httpOnly and cannot
  * be read server-side; SSR init would always fail inside Docker (localhost:4433
  * is not reachable from the container) and would poison the store with
  * initialized=true / session=null, causing the middleware to redirect to login.
+ *
+ * Also owns the boot splash dismissal (standalone PWA only — see
+ * useSplashScreen / SplashScreen.vue): the splash stays up through the async
+ * session check and is dismissed once we know where the app is going.
  */
+import { useAuthStore } from '~/stores/auth'
+
 export default defineNuxtPlugin(async () => {
   // Skip on SSR — middleware already returns early on server
   if (import.meta.server) {
@@ -13,9 +19,37 @@ export default defineNuxtPlugin(async () => {
   }
 
   const authStore = useAuthStore()
+  const router = useRouter()
+  const { markReady } = useSplashScreen()
 
   // Load authentication state by checking the Kratos session
   await authStore.loadFromCookies()
+
+  const isBootRoute = (path: string) => path === '/' || path === '/calendar'
+
+  if (!authStore.isAuthenticated) {
+    // Anonymous: reveal the landing / login page immediately.
+    markReady()
+  }
+  else if (!isBootRoute(router.currentRoute.value.path)) {
+    // Authenticated deep-link / refresh onto a non-calendar page: that page
+    // owns its own skeletons, so dismiss as soon as it takes over.
+    markReady()
+  }
+  else {
+    // Normal relaunch path (`/` redirects to `/calendar`): the calendar hides
+    // the splash once its first data load finishes. Guard against ever getting
+    // stuck if the redirect lands somewhere unexpected.
+    const stop = router.afterEach((to) => {
+      if (!isBootRoute(to.path)) {
+        markReady()
+        stop()
+      }
+    })
+  }
+
+  // Safety net: never let the splash trap the user, whatever happens above.
+  setTimeout(markReady, 6000)
 
   // Setup visibility listener to handle long-running background tabs
   authStore.setupVisibilityListener()

--- a/Homassy.Web/i18n/locales/de.json
+++ b/Homassy.Web/i18n/locales/de.json
@@ -1,4 +1,7 @@
 {
+  "splash": {
+    "welcomeBack": "Willkommen zurück"
+  },
   "meta": {
     "default": {
       "title": "Homassy - Familienhaushalts-Verwaltung",

--- a/Homassy.Web/i18n/locales/en.json
+++ b/Homassy.Web/i18n/locales/en.json
@@ -1,4 +1,7 @@
 {
+  "splash": {
+    "welcomeBack": "Welcome back"
+  },
   "meta": {
     "default": {
       "title": "Homassy - Family Household Management",

--- a/Homassy.Web/i18n/locales/hu.json
+++ b/Homassy.Web/i18n/locales/hu.json
@@ -1,4 +1,7 @@
 {
+  "splash": {
+    "welcomeBack": "Üdv újra itt"
+  },
   "meta": {
     "default": {
       "title": "Homassy - Családi háztartáskezelés",

--- a/Homassy.Web/nuxt.config.ts
+++ b/Homassy.Web/nuxt.config.ts
@@ -62,6 +62,9 @@ export default defineNuxtConfig({
       name: 'Homassy',
       short_name: 'Homassy',
       theme_color: '#c9b8a0',
+      // Matches the in-app splash background so the OS-generated launch screen
+      // hands off seamlessly into it.
+      background_color: '#c9b8a0',
       display: 'standalone',
       start_url: '/',
       icons: [
@@ -79,6 +82,25 @@ export default defineNuxtConfig({
           src: '/apple-touch-icon-180x180.png',
           sizes: '180x180',
           type: 'image/png'
+        },
+        // >=192px icons enable Android's branded generated splash screen.
+        {
+          src: '/android-chrome-192x192.png',
+          sizes: '192x192',
+          type: 'image/png',
+          purpose: 'any'
+        },
+        {
+          src: '/android-chrome-512x512.png',
+          sizes: '512x512',
+          type: 'image/png',
+          purpose: 'any'
+        },
+        {
+          src: '/android-chrome-512x512.png',
+          sizes: '512x512',
+          type: 'image/png',
+          purpose: 'maskable'
         }
       ]
     },


### PR DESCRIPTION
## Summary

Show a branded splash while the app boots as an installed PWA, covering the async Kratos session check, the redirect, and the calendar's first data load — so a returning user no longer sees a blank screen before the calendar. Shows the logo, the user's name, the app version, and a spinner.

- Add `SplashScreen` overlay (logo, welcome + name, spinner, version footer) rendered in `app.vue`; visible **only** in standalone display-mode via a pure CSS `@media (display-mode: standalone)` query, so it paints server-side with no hydration mismatch and never appears in a normal browser tab
- Add `useSplashScreen` composable; dismissal stamps `data-splash-ready` on `<html>` instead of a reactive flag, keeping it outside Vue's hydration diff
- Dismiss on the first of: anonymous after auth resolves, calendar first load done, a non-boot deep-link settling, or a 6s safety timeout
- Reuse the profile version source (`GET /api/Version`) for the version footer
- Brand the native OS launch screen: manifest `background_color` + 192/512 (`any` + `maskable`) icons, so the OS-generated splash hands off seamlessly into the in-app one
- Localize `splash.welcomeBack` in `en`/`hu`/`de`