### PR TITLE
fix(pwa): show boot splash on iOS standalone launch

### DIFF
--- a/Homassy.Web/app/components/SplashScreen.vue
+++ b/Homassy.Web/app/components/SplashScreen.vue
@@ -72,13 +72,21 @@ onMounted(async () => {
   transition: opacity 0.3s ease;
 }
 
-/* Only ever visible when launched as an installed PWA. */
+/* Only ever visible when launched as an installed PWA. `pwa-standalone` is set
+   by the inline head script (covers iOS, where the media query is unreliable);
+   the media query covers Android/desktop installed PWAs. */
 @media all and (display-mode: standalone) {
   .splash {
     display: flex;
     align-items: center;
     justify-content: center;
   }
+}
+
+:root.pwa-standalone .splash {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* Dismissal: stamped on <html> by useSplashScreen().markReady(). */

--- a/Homassy.Web/nuxt.config.ts
+++ b/Homassy.Web/nuxt.config.ts
@@ -26,6 +26,18 @@ export default defineNuxtConfig({
         { rel: 'apple-touch-icon', sizes: '152x152', href: '/apple-touch-icon-152x152.png' },
         { rel: 'apple-touch-icon', href: '/apple-touch-icon.png' },
         { rel: 'mask-icon', href: '/safari-pinned-tab.svg', color: '#c9b8a0' }
+      ],
+      script: [
+        // Flag standalone/PWA launches before first paint so the boot splash
+        // (SplashScreen.vue) can show. iOS home-screen web apps do not reliably
+        // match `@media (display-mode: standalone)`, so we also check the
+        // iOS-only `navigator.standalone`. Runs synchronously in <head> — no flash.
+        {
+          innerHTML:
+            '(function(){try{if(window.navigator.standalone===true||window.matchMedia("(display-mode: standalone)").matches){document.documentElement.classList.add("pwa-standalone")}}catch(e){}})()',
+          tagPosition: 'head',
+          tagPriority: 1
+        }
       ]
     }
   },


### PR DESCRIPTION
## Summary

Follow-up to #54. On iOS the boot splash never appeared: iOS home-screen web apps do not reliably match the `@media (display-mode: standalone)` query, so the overlay stayed `display:none` and the user saw the public layout flash before the redirect and calendar load.

- Detect the iOS-only `navigator.standalone` (plus the media query) in an inline `<head>` script that runs before first paint and adds a `pwa-standalone` class to `<html>` — no flash
- Gate the splash on `:root.pwa-standalone .splash` in addition to the standalone media query