### PR TITLE
feat(pwa): keep boot splash visible for a minimum time

### DIFF
--- a/Homassy.Web/app/composables/useSplashScreen.ts
+++ b/Homassy.Web/app/composables/useSplashScreen.ts
@@ -2,18 +2,41 @@
  * Splash screen state.
  *
  * The boot splash is shown ONLY in standalone PWA mode — that decision is made
- * purely in CSS (`@media (display-mode: standalone)`), so the overlay can render
- * in the SSR HTML and paint on the very first frame without any hydration
- * mismatch. This composable only handles dismissal: `markReady()` stamps a
- * `data-splash-ready` attribute on <html>, which CSS uses to fade the overlay
- * out. Toggling an attribute on the document (instead of a reactive `v-if`)
- * keeps dismissal completely outside Vue's hydration diff, so it works even
- * when it fires before the app mounts (e.g. the anonymous fast-path).
+ * in CSS (`@media (display-mode: standalone)` + a `pwa-standalone` class set by
+ * an inline head script for iOS), so the overlay can render in the SSR HTML and
+ * paint on the very first frame without any hydration mismatch. This composable
+ * only handles dismissal: `markReady()` stamps a `data-splash-ready` attribute
+ * on <html>, which CSS uses to fade the overlay out. Toggling an attribute on
+ * the document (instead of a reactive `v-if`) keeps dismissal completely outside
+ * Vue's hydration diff, so it works even when it fires before the app mounts.
+ *
+ * Minimum visible time: when the app is ready very fast (cached calendar), the
+ * splash would flash too briefly to read. `markReady()` therefore never hides
+ * the splash before MIN_VISIBLE_MS has elapsed; a slow load still hides exactly
+ * when it becomes ready (no extra artificial delay).
  */
+const MIN_VISIBLE_MS = 1800
+
+// Client-only baseline ≈ when the splash first became visible (first paint).
+let shownAt: number | null = null
+
 export function useSplashScreen() {
+  if (import.meta.client && shownAt === null) {
+    shownAt = performance.now()
+  }
+
+  const reveal = () => {
+    document.documentElement.setAttribute('data-splash-ready', 'true')
+  }
+
   const markReady = () => {
-    if (import.meta.client) {
-      document.documentElement.setAttribute('data-splash-ready', 'true')
+    if (!import.meta.client) return
+    const remaining = MIN_VISIBLE_MS - (performance.now() - (shownAt ?? performance.now()))
+    if (remaining > 0) {
+      window.setTimeout(reveal, remaining)
+    }
+    else {
+      reveal()
     }
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #54 / #55. When the calendar is cached the app can be ready in a few hundred milliseconds, so the boot splash flashed by too fast to read the name and version. Hold the splash for a minimum time before dismissing it.

- `markReady()` now reveals the app only after at least 1.8s of splash visibility (measured from first paint); if the app is ready sooner, dismissal is deferred to that floor
- A slow load is unaffected — the splash still hides exactly when the app becomes ready, with no added delay
- Repeated `markReady()` calls (auth resolve, calendar reload, safety timeout) remain idempotent