### PR TITLE
feat(pwa): redesign boot splash, re-show when idle

### DIFF
--- a/Homassy.Web/app/components/SplashScreen.vue
+++ b/Homassy.Web/app/components/SplashScreen.vue
@@ -3,10 +3,10 @@ import { useAuthStore } from '~/stores/auth'
 import type { VersionInfo } from '~/types/version'
 
 // Boot splash shown only when running as an installed PWA (standalone display
-// mode — enforced in CSS below). Logo + spinner render server-side so they
-// paint during the pre-hydration auth window; the name/version are client-only
-// (auth + version resolve after hydration) and are wrapped in <ClientOnly> to
-// avoid a hydration mismatch.
+// mode — enforced in CSS below). Logo + the loading ring around it render
+// server-side so they paint during the pre-hydration auth window; the
+// name/version are client-only (auth + version resolve after hydration) and are
+// wrapped in <ClientOnly> to avoid a hydration mismatch.
 
 const authStore = useAuthStore()
 
@@ -35,13 +35,16 @@ onMounted(async () => {
 <template>
   <div class="splash" aria-hidden="true">
     <div class="splash__inner">
-      <img
-        src="/favicon.svg"
-        alt="Homassy"
-        class="splash__logo"
-        width="88"
-        height="88"
-      >
+      <div class="splash__badge">
+        <div class="splash__ring" role="status" :aria-label="$t('common.loading')" />
+        <img
+          src="/favicon.svg"
+          alt="Homassy"
+          class="splash__logo"
+          width="88"
+          height="88"
+        >
+      </div>
 
       <ClientOnly>
         <p v-if="userName" class="splash__welcome">
@@ -49,8 +52,6 @@ onMounted(async () => {
           <span class="splash__name">{{ userName }}</span>
         </p>
       </ClientOnly>
-
-      <div class="splash__spinner" role="status" :aria-label="$t('common.loading')" />
     </div>
 
     <ClientOnly>
@@ -67,8 +68,8 @@ onMounted(async () => {
   position: fixed;
   inset: 0;
   z-index: 2147483000;
-  background-color: #c9b8a0;
-  color: #2b2620;
+  background-color: #2b2620;
+  color: #f5eee2;
   transition: opacity 0.3s ease;
 }
 
@@ -104,10 +105,31 @@ onMounted(async () => {
   padding: 2rem;
 }
 
+/* The loading ring is a rotating conic arc, masked into a thin band so the
+   espresso background shows through its centre; the static logo sits on top. */
+.splash__badge {
+  position: relative;
+  width: 128px;
+  height: 128px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.splash__ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: conic-gradient(from 0deg, #f0e6d6 0deg 250deg, #413a31 250deg 360deg);
+  -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 7px), #000 calc(100% - 7px));
+  mask: radial-gradient(farthest-side, transparent calc(100% - 7px), #000 calc(100% - 7px));
+  animation: splash-spin 0.9s linear infinite;
+}
+
 .splash__logo {
   width: 88px;
   height: 88px;
-  filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.15));
+  filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.25));
 }
 
 .splash__welcome {
@@ -118,22 +140,13 @@ onMounted(async () => {
 .splash__welcome-label {
   display: block;
   font-size: 0.8rem;
-  opacity: 0.7;
+  color: #a58e74;
 }
 
 .splash__name {
   display: block;
   font-size: 1.35rem;
   font-weight: 600;
-}
-
-.splash__spinner {
-  width: 34px;
-  height: 34px;
-  border-radius: 50%;
-  border: 3px solid rgba(43, 38, 32, 0.25);
-  border-top-color: #2b2620;
-  animation: splash-spin 0.8s linear infinite;
 }
 
 .splash__version {
@@ -153,8 +166,8 @@ onMounted(async () => {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .splash__spinner {
-    animation-duration: 1.6s;
+  .splash__ring {
+    animation-duration: 2.4s;
   }
 }
 </style>

--- a/Homassy.Web/app/composables/useSplashScreen.ts
+++ b/Homassy.Web/app/composables/useSplashScreen.ts
@@ -14,6 +14,10 @@
  * splash would flash too briefly to read. `markReady()` therefore never hides
  * the splash before MIN_VISIBLE_MS has elapsed; a slow load still hides exactly
  * when it becomes ready (no extra artificial delay).
+ *
+ * Re-show on resume: `rearm()` reverses the dismissal (removes the attribute and
+ * restarts the minimum-visible baseline) so the splash can be shown again when
+ * the PWA is resumed after a long background gap — see plugins/splash-resume.
  */
 const MIN_VISIBLE_MS = 1800
 
@@ -29,6 +33,14 @@ export function useSplashScreen() {
     document.documentElement.setAttribute('data-splash-ready', 'true')
   }
 
+  const rearm = () => {
+    if (!import.meta.client) return
+    // Restart the MIN_VISIBLE_MS floor from now so a resumed splash is also
+    // readable, then drop the attribute so CSS shows .splash again (standalone).
+    shownAt = performance.now()
+    document.documentElement.removeAttribute('data-splash-ready')
+  }
+
   const markReady = () => {
     if (!import.meta.client) return
     const remaining = MIN_VISIBLE_MS - (performance.now() - (shownAt ?? performance.now()))
@@ -40,5 +52,5 @@ export function useSplashScreen() {
     }
   }
 
-  return { markReady }
+  return { markReady, rearm }
 }

--- a/Homassy.Web/app/plugins/splash-resume.client.ts
+++ b/Homassy.Web/app/plugins/splash-resume.client.ts
@@ -1,0 +1,60 @@
+/**
+ * Re-show the boot splash after a long PWA background gap.
+ *
+ * The splash (SplashScreen.vue / useSplashScreen) is a CSS overlay that paints
+ * on a full document load and is then dismissed one-way. A background→foreground
+ * resume of the SAME still-alive document therefore never re-shows it — which is
+ * exactly what we want for quick app-switching. But when the OS keeps the PWA
+ * alive and the user returns after a long absence, it should feel like a fresh
+ * launch. This plugin watches page-lifecycle events and, when the document was
+ * backgrounded for at least RESUME_SPLASH_MS, re-arms the splash for a brief,
+ * self-dismissing flash. (A background gap long enough for the OS to KILL the
+ * app is a cold launch = full document load = splash already shows, so that case
+ * needs no handling here.)
+ *
+ * Standalone-only: the splash CSS only renders as an installed PWA, so the
+ * listeners are skipped in a normal browser tab.
+ */
+import { useSplashScreen } from '~/composables/useSplashScreen'
+
+const RESUME_SPLASH_MS = 10 * 60 * 1000 // re-show splash after ≥10 min backgrounded
+
+export default defineNuxtPlugin(() => {
+  if (import.meta.server) return
+
+  const isStandalone = () =>
+    (window.navigator as unknown as { standalone?: boolean }).standalone === true
+    || window.matchMedia('(display-mode: standalone)').matches
+  if (!isStandalone()) return
+
+  const { markReady, rearm } = useSplashScreen()
+  // Plugin-scoped: one alive document == one JS realm. No storage needed — a
+  // killed app is a cold boot that shows the splash anyway.
+  let lastHiddenAt: number | null = null
+
+  // Wall-clock Date.now(): accurate across a suspension even though background
+  // JS timers are throttled/paused.
+  const onHidden = () => {
+    lastHiddenAt = Date.now()
+  }
+
+  const onVisible = () => {
+    if (lastHiddenAt !== null && Date.now() - lastHiddenAt >= RESUME_SPLASH_MS) {
+      rearm() // re-show the splash overlay
+      markReady() // dismiss again after the minimum-visible floor
+    }
+    lastHiddenAt = null
+  }
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') onHidden()
+    else if (document.visibilityState === 'visible') onVisible()
+  })
+
+  // BFCache / suspend safety net (notably iOS): pagehide stamps the time, and a
+  // restored pageshow re-checks the gap even if visibilitychange did not fire.
+  window.addEventListener('pagehide', onHidden)
+  window.addEventListener('pageshow', (e) => {
+    if ((e as PageTransitionEvent).persisted) onVisible()
+  })
+})

--- a/Homassy.Web/nuxt.config.ts
+++ b/Homassy.Web/nuxt.config.ts
@@ -75,8 +75,8 @@ export default defineNuxtConfig({
       short_name: 'Homassy',
       theme_color: '#c9b8a0',
       // Matches the in-app splash background so the OS-generated launch screen
-      // hands off seamlessly into it.
-      background_color: '#c9b8a0',
+      // hands off seamlessly into it (SplashScreen.vue uses the same espresso).
+      background_color: '#2b2620',
       display: 'standalone',
       start_url: '/',
       icons: [


### PR DESCRIPTION
## Summary

Redesign the PWA boot splash so it stays legible, and re-show it after the app has been backgrounded for a long time.

- Re-show the boot splash on resume when the PWA was backgrounded for at least 10 minutes (`useSplashScreen` `rearm()` + new `splash-resume.client.ts`); quick app-switches are left untouched, and an OS-killed app already cold-launches with the splash.
- Restyle the splash with an espresso background and cream text so the logo and welcome name stay legible — the previous dark text on the tan background washed out.
- Replace the standalone spinner with a loading ring around the logo.
- Point the manifest `background_color` at the new splash colour so the OS-generated launch screen still hands off seamlessly.
