### PR TITLE
feat(ui): bubble enter/leave animation for list items

### DIFF
--- a/Homassy.Web/app/assets/css/main.css
+++ b/Homassy.Web/app/assets/css/main.css
@@ -23,6 +23,16 @@
    var(--app-header-height) safely. */
 :root {
   --app-header-height: 5.5rem;
+
+  /* Bubble list transition — always driven through <AnimatedList>. */
+  --bubble-in: 280ms;
+  --bubble-out: 180ms;
+  --bubble-move: 260ms;
+  --bubble-stagger: 28ms;
+  /* Overshoot curve — the same one the FAB and the swipe commit use. */
+  --bubble-ease-pop: cubic-bezier(0.34, 1.56, 0.64, 1);
+  /* Decelerating curve for movement/settling — the nav/snap easing. */
+  --bubble-ease-out: cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 /* Page content cross-fade on navigation (the bottom nav + header stay fixed in the layout). */
@@ -43,5 +53,73 @@
   .page-enter-active,
   .page-leave-active {
     transition: none;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+   Bubble list transition — see app/components/AnimatedList.vue.
+
+   Enter: the card pops from small to full size with a slight overshoot while
+   fading in. Leave: it bursts (scales up a touch) and fades out. The cards
+   around it glide into their new cell via the FLIP `-move` transition. Only
+   transform + opacity are animated, so it stays on the compositor.
+
+   Leaving cards are taken out of flow by AnimatedList, which writes inline
+   position/top/left/width/height — a bare `position: absolute` here would not
+   work, because an auto-placed abspos child of a CSS grid resolves against the
+   grid's padding box and would jump to its top-left corner at content width.
+
+   These rules are deliberately unlayered (like .page-* above), so they outrank
+   Tailwind's @layer utilities — otherwise a card's own `hover:-translate-y-0.5`
+   would fight the enter transform.
+
+   ORDER: `.bubble-move` must stay ABOVE `.bubble-leave-active`. A pinned card
+   can measure a fraction of a pixel off, which is enough for TransitionGroup to
+   treat it as "moved" and add `.bubble-move` alongside `.bubble-leave-active`;
+   at equal specificity the later `transition` wins, and it has to be the leave
+   one — otherwise the opacity fade is dropped and the card blinks out.
+--------------------------------------------------------------------------- */
+.bubble-move {
+  transition: transform var(--bubble-move) var(--bubble-ease-out);
+}
+
+.bubble-enter-active {
+  /* Only a list's first render is staggered: AnimatedList sets --bubble-index
+     during the appear pass and clears it afterwards, so cards arriving later
+     (SignalR, infinite scroll) start immediately. */
+  --bubble-delay: calc(var(--bubble-index, 0) * var(--bubble-stagger));
+  transition:
+    opacity var(--bubble-in) var(--bubble-ease-out) var(--bubble-delay),
+    transform var(--bubble-in) var(--bubble-ease-pop) var(--bubble-delay);
+}
+
+.bubble-enter-from {
+  opacity: 0;
+  transform: scale(0.82);
+}
+
+.bubble-leave-active {
+  transition:
+    opacity var(--bubble-out) ease-in,
+    transform var(--bubble-out) var(--bubble-ease-out);
+}
+
+.bubble-leave-to {
+  opacity: 0;
+  /* Deliberately small: a bigger burst on a 2-column mobile grid pushes the
+     card past the viewport edge and flashes a horizontal scrollbar. */
+  transform: scale(1.08);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bubble-move,
+  .bubble-enter-active,
+  .bubble-leave-active {
+    transition: none;
+  }
+  /* Without this the card still paints one frame at scale(0.82). */
+  .bubble-enter-from,
+  .bubble-leave-to {
+    transform: none;
   }
 }

--- a/Homassy.Web/app/components/ActivityCard.vue
+++ b/Homassy.Web/app/components/ActivityCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="p-4 rounded-xl shadow-sm bg-gradient-to-br from-white to-gray-50 dark:from-gray-800 dark:to-gray-900 hover:shadow-lg hover:-translate-y-0.5 transition-all duration-200 slideInUp"
+    class="p-4 rounded-xl shadow-sm bg-gradient-to-br from-white to-gray-50 dark:from-gray-800 dark:to-gray-900 hover:shadow-lg hover:-translate-y-0.5 transition-all duration-200"
   >
     <!-- Header: User info and timestamp -->
     <div class="flex items-start gap-3 mb-3">

--- a/Homassy.Web/app/components/AnimatedList.vue
+++ b/Homassy.Web/app/components/AnimatedList.vue
@@ -1,0 +1,232 @@
+<script setup lang="ts">
+/**
+ * Shared wrapper for every animated list/grid in the app.
+ *
+ * Renders a <TransitionGroup> so the transition name, the container classes and
+ * the leave-pinning logic live in one place instead of being repeated per call
+ * site. The CSS is defined once in app/assets/css/main.css (`.bubble-*`).
+ *
+ * Usage — this REPLACES the plain <div> that held the v-for, and takes over its
+ * classes (a nested wrapper would break `grid` and `space-y-*`, both of which
+ * are direct-child selectors):
+ *
+ *   <AnimatedList class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+ *     <DetailedProductCard v-for="p in items" :key="p.publicId" :product="p" />
+ *   </AnimatedList>
+ *
+ * Two rules for the slot content:
+ *   - exactly one root element per keyed child (wrap a v-if/v-else pair in a div)
+ *   - a stable :key from the server (publicId) — never the v-for index
+ *
+ * Also: no child's root may carry a CSS `animation` longer than the move
+ * duration. TransitionGroup detects FLIP support by cloning the first child and
+ * reading its computed timings; a longer animation makes it report "no
+ * transform transition" and silently disables the move animation entirely.
+ *
+ * Note that this component never re-renders when the list changes — the slot is
+ * a stable compiled slot, so the parent patches the transition's children
+ * directly. All the logic below therefore runs from the transition hooks, never
+ * from this component's own update hooks (see `openBatch`).
+ *
+ * Do not set inheritAttrs: false — the call site's `class` reaches the rendered
+ * container through attribute fallthrough and is merged with `relative` below.
+ */
+const props = withDefaults(defineProps<{
+  /** Element rendered as the list container. */
+  tag?: string
+  /** Transition name; the classes are defined once in main.css. */
+  name?: string
+  /** Animate the items already present on the list's first render. */
+  appear?: boolean
+  /** Stagger that first render (no effect when `appear` is false). */
+  stagger?: boolean
+  /** Highest index that still gets a delay, so long lists stay snappy. */
+  staggerLimit?: number
+  /**
+   * Most items animated in a single update. A filter change can drop dozens of
+   * cards at once; past this many the rest are removed/inserted without
+   * animation rather than compositing that many layers on a mid-range phone.
+   */
+  batchLimit?: number
+  /** Render a plain container with no transition at all (static flag). */
+  disabled?: boolean
+}>(), {
+  tag: 'div',
+  name: 'bubble',
+  appear: true,
+  stagger: true,
+  staggerLimit: 12,
+  batchLimit: 12,
+  disabled: false
+})
+
+// prefers-reduced-motion is honoured in CSS (transition: none). The pinning
+// below has to be skipped too, otherwise a removed card is yanked out of flow
+// for the frame it takes to remove it.
+const reducedMotion = () =>
+  import.meta.client && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+interface Box { top: number, left: number, width: number, height: number }
+
+/**
+ * Layout of every in-flow child, captured on the first removal of a patch — so a
+ * leaving card can be pinned to its own cell and the survivors can close the gap
+ * under the FLIP `-move` transition.
+ *
+ * It has to be a snapshot, not a per-card measurement: pinning takes a card out
+ * of flow, so the grid reflows immediately and every *later* removal in the same
+ * batch would measure a shifted cell. Filtering drops many cards at once, so
+ * this is the common case, not an edge case.
+ */
+let boxes: Map<HTMLElement, Box> | null = null
+
+const measure = (container: HTMLElement) => {
+  const map = new Map<HTMLElement, Box>()
+  boxes = map
+  const cRect = container.getBoundingClientRect()
+  const cStyle = getComputedStyle(container)
+  // `top`/`left` on an abspos child resolve against the padding box and are
+  // unaffected by scrolling — fold the border and the scroll offset in here.
+  const originTop = cRect.top + Number.parseFloat(cStyle.borderTopWidth) - container.scrollTop
+  const originLeft = cRect.left + Number.parseFloat(cStyle.borderLeftWidth) - container.scrollLeft
+
+  for (const child of Array.from(container.children)) {
+    const el = child as HTMLElement
+    if (el.style.position === 'absolute') continue // already leaving
+    const r = el.getBoundingClientRect()
+    map.set(el, {
+      top: r.top - originTop,
+      left: r.left - originLeft,
+      width: r.width,
+      height: r.height
+    })
+  }
+}
+
+let enterCount = 0
+let leaveCount = 0
+let batchOpen = false
+
+/**
+ * Per-batch bookkeeping.
+ *
+ * This component's own update hooks (onBeforeUpdate/onUpdated) are NOT usable
+ * here: the slot content is a stable compiled slot, so the parent patches the
+ * transition's children directly without re-rendering this component, and the
+ * hooks never fire. Everything therefore hangs off the first transition hook of
+ * a patch, and a microtask closes the batch — Vue's scheduler flush is
+ * synchronous, so a microtask queued from inside it runs once the whole flush
+ * (patch + post-render enter hooks) is done.
+ *
+ * Without this the counters below would never reset and `batchLimit` would
+ * permanently disable the animation after that many cumulative items.
+ */
+const openBatch = () => {
+  if (batchOpen) return
+  batchOpen = true
+  queueMicrotask(() => {
+    batchOpen = false
+    boxes = null // also drops references to the detached leaving nodes
+    enterCount = 0
+    leaveCount = 0
+  })
+}
+
+/**
+ * Opt an element out of its transition. Inline style beats the transition
+ * class, so the computed duration is 0 and Vue resolves on the next frame
+ * instead of waiting for a transitionend. Cleaned up in the after-hooks.
+ */
+const skip = (el: Element) => {
+  (el as HTMLElement).style.transition = 'none'
+}
+const unskip = (el: Element) => {
+  (el as HTMLElement).style.removeProperty('transition')
+}
+
+/**
+ * Undo the leave pinning. Needed when a leave is *cancelled* — an item removed
+ * and re-added within the leave duration keeps the same element, which would
+ * otherwise stay absolutely positioned for good.
+ */
+const unpin = (el: Element) => {
+  const style = (el as HTMLElement).style
+  for (const prop of ['position', 'top', 'left', 'width', 'height', 'margin', 'pointer-events', 'transition']) {
+    style.removeProperty(prop)
+  }
+}
+
+// Every hook below takes exactly one argument on purpose: Vue treats a two-arg
+// hook as taking an explicit `done` callback and would wait forever for it.
+const onBeforeLeave = (el: Element) => {
+  openBatch()
+  if (props.disabled || reducedMotion()) return
+  if (++leaveCount > props.batchLimit) return skip(el)
+
+  const node = el as HTMLElement
+  const container = node.parentElement
+  if (!container) return
+
+  // First removal of this patch: snapshot the list while every card is still in
+  // flow and nothing has been pinned yet. Vue unmounts before it moves survivors,
+  // so this is the pre-update geometry for the whole batch.
+  if (!boxes) measure(container)
+
+  const box = boxes?.get(node)
+  if (!box) return
+
+  const style = node.style
+  style.position = 'absolute'
+  style.top = `${box.top}px`
+  style.left = `${box.left}px`
+  style.width = `${box.width}px`
+  style.height = `${box.height}px`
+  style.margin = '0' // space-y-* margins would offset an abspos box
+  style.pointerEvents = 'none' // a bursting card must not swallow taps
+}
+
+// Stagger the first render only. Vue calls @appear exclusively for the initial
+// pass and @enter for every later insertion, so cards arriving over SignalR or
+// from infinite scroll come in without a delay. The index is the hook call
+// order, which is the mount order — call sites never pass one.
+let appearIndex = 0
+const onAppear = (el: Element) => {
+  if (!props.stagger) return
+  const i = Math.min(appearIndex++, props.staggerLimit)
+  ;(el as HTMLElement).style.setProperty('--bubble-index', String(i))
+}
+const onAfterAppear = (el: Element) => {
+  (el as HTMLElement).style.removeProperty('--bubble-index')
+}
+
+const onEnter = (el: Element) => {
+  openBatch()
+  if (++enterCount > props.batchLimit) skip(el)
+}
+</script>
+
+<template>
+  <!-- `disabled` renders a plain container rather than passing :css="false" —
+       with css: false Vue waits on a `done` callback the one-arg hooks above
+       never call, which would strand leaving elements in the DOM. -->
+  <component :is="tag" v-if="disabled" class="relative">
+    <slot />
+  </component>
+  <TransitionGroup
+    v-else
+    :tag="tag"
+    :name="name"
+    :appear="appear"
+    class="relative"
+    @appear="onAppear"
+    @after-appear="onAfterAppear"
+    @appear-cancelled="onAfterAppear"
+    @enter="onEnter"
+    @after-enter="unskip"
+    @enter-cancelled="unskip"
+    @before-leave="onBeforeLeave"
+    @leave-cancelled="unpin"
+  >
+    <slot />
+  </TransitionGroup>
+</template>

--- a/Homassy.Web/app/components/DataAutomationCard.vue
+++ b/Homassy.Web/app/components/DataAutomationCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative rounded-2xl overflow-hidden card-animate" style="touch-action: pan-y" data-no-pull-refresh>
+  <div class="relative rounded-2xl overflow-hidden" style="touch-action: pan-y" data-no-pull-refresh>
     <!-- Swipe action layer -->
     <div
       v-show="swipe.isSwiping.value"
@@ -162,13 +162,3 @@ async function handleDelete() {
   }
 }
 </script>
-
-<style scoped>
-@keyframes slideInUp {
-  from { opacity: 0; transform: translateY(20px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-.card-animate {
-  animation: slideInUp 0.4s ease-out;
-}
-</style>

--- a/Homassy.Web/app/components/DataExternalCalendarCard.vue
+++ b/Homassy.Web/app/components/DataExternalCalendarCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative rounded-2xl overflow-hidden card-animate" style="touch-action: pan-y" data-no-pull-refresh>
+  <div class="relative rounded-2xl overflow-hidden" style="touch-action: pan-y" data-no-pull-refresh>
     <!-- Swipe action layer -->
     <div
       v-show="swipe.isSwiping.value"
@@ -128,13 +128,3 @@ const formatTimestamp = (timestamp: string): string => {
   return date.toLocaleDateString()
 }
 </script>
-
-<style scoped>
-@keyframes slideInUp {
-  from { opacity: 0; transform: translateY(20px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-.card-animate {
-  animation: slideInUp 0.4s ease-out;
-}
-</style>

--- a/Homassy.Web/app/components/DataProductCard.vue
+++ b/Homassy.Web/app/components/DataProductCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative rounded-2xl overflow-hidden card-animate" style="touch-action: pan-y" data-no-pull-refresh>
+  <div class="relative rounded-2xl overflow-hidden" style="touch-action: pan-y" data-no-pull-refresh>
     <!-- Swipe action layer -->
     <div
       v-show="swipe.isSwiping.value"
@@ -135,13 +135,3 @@ async function handleDelete() {
   }
 }
 </script>
-
-<style scoped>
-@keyframes slideInUp {
-  from { opacity: 0; transform: translateY(20px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-.card-animate {
-  animation: slideInUp 0.4s ease-out;
-}
-</style>

--- a/Homassy.Web/app/components/DataShoppingLocationCard.vue
+++ b/Homassy.Web/app/components/DataShoppingLocationCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative rounded-2xl overflow-hidden card-animate" style="touch-action: pan-y" data-no-pull-refresh>
+  <div class="relative rounded-2xl overflow-hidden" style="touch-action: pan-y" data-no-pull-refresh>
     <!-- Swipe action layer -->
     <div
       v-show="swipe.isSwiping.value"
@@ -171,13 +171,3 @@ async function handleDelete() {
   }
 }
 </script>
-
-<style scoped>
-@keyframes slideInUp {
-  from { opacity: 0; transform: translateY(20px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-.card-animate {
-  animation: slideInUp 0.4s ease-out;
-}
-</style>

--- a/Homassy.Web/app/components/DataStorageLocationCard.vue
+++ b/Homassy.Web/app/components/DataStorageLocationCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative rounded-2xl overflow-hidden card-animate" style="touch-action: pan-y" data-no-pull-refresh>
+  <div class="relative rounded-2xl overflow-hidden" style="touch-action: pan-y" data-no-pull-refresh>
     <!-- Swipe action layer (revealed behind the card while dragging) -->
     <div
       v-show="swipe.isSwiping.value"
@@ -128,13 +128,3 @@ async function handleDelete() {
   }
 }
 </script>
-
-<style scoped>
-@keyframes slideInUp {
-  from { opacity: 0; transform: translateY(20px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-.card-animate {
-  animation: slideInUp 0.4s ease-out;
-}
-</style>

--- a/Homassy.Web/app/components/DetailedProductCard.vue
+++ b/Homassy.Web/app/components/DetailedProductCard.vue
@@ -2,7 +2,7 @@
   <div
     role="button"
     tabindex="0"
-    class="group relative bg-default rounded-2xl border-2 p-3 cursor-pointer shadow-sm hover:shadow-lg transition-shadow duration-200 flex flex-col overflow-hidden card-animate"
+    class="group relative bg-default rounded-2xl border-2 p-3 cursor-pointer shadow-sm hover:shadow-lg transition-shadow duration-200 flex flex-col overflow-hidden"
     :class="cardBorderClass"
     @click="selectProduct"
     @keydown.enter="selectProduct"
@@ -148,20 +148,3 @@ const selectProduct = () => {
   emit('select', props.product.publicId)
 }
 </script>
-
-<style scoped>
-@keyframes slideInUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.card-animate {
-  animation: slideInUp 0.4s ease-out;
-}
-</style>

--- a/Homassy.Web/app/components/InventoryItemList.vue
+++ b/Homassy.Web/app/components/InventoryItemList.vue
@@ -24,7 +24,7 @@
     </div>
 
     <!-- Full-width rows -->
-    <div v-else class="space-y-2">
+    <AnimatedList v-else class="space-y-2">
       <InventoryItemRow
         v-for="item in items"
         :key="item.publicId"
@@ -34,7 +34,7 @@
         @updated="emit('refresh')"
         @deleted="emit('refresh')"
       />
-    </div>
+    </AnimatedList>
 
     <!-- Felosztás / Készlet mozgatás operations (⚙) -->
     <InventoryOperationsDrawer

--- a/Homassy.Web/app/components/InventoryItemRow.vue
+++ b/Homassy.Web/app/components/InventoryItemRow.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="relative rounded-xl overflow-hidden slideInUp"
+    class="relative rounded-xl overflow-hidden"
     style="touch-action: pan-y"
     data-no-pull-refresh
   >
@@ -484,20 +484,3 @@ const handleDelete = async () => {
   }
 }
 </script>
-
-<style scoped>
-@keyframes slideInUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.slideInUp {
-  animation: slideInUp 0.4s ease-out;
-}
-</style>

--- a/Homassy.Web/app/components/SelectableProductCard.vue
+++ b/Homassy.Web/app/components/SelectableProductCard.vue
@@ -1,6 +1,6 @@
 ﻿<template>
   <div
-    class="group relative bg-gradient-to-br from-white to-gray-50 dark:from-gray-800 dark:to-gray-900 rounded-xl border-2 p-3 cursor-pointer hover:shadow-lg hover:-translate-y-0.5 transition-all duration-200 flex flex-col overflow-hidden card-animate"
+    class="group relative bg-gradient-to-br from-white to-gray-50 dark:from-gray-800 dark:to-gray-900 rounded-xl border-2 p-3 cursor-pointer hover:shadow-lg hover:-translate-y-0.5 transition-all duration-200 flex flex-col overflow-hidden"
     :class="[cardBorderClass, isSelected && 'ring-2 ring-offset-2 ring-primary-500 dark:ring-offset-gray-900']"
     @click="handleCardClick"
   >
@@ -119,20 +119,3 @@ const handleCardClick = () => {
   emit('select', props.product)
 }
 </script>
-
-<style scoped>
-@keyframes slideInUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.card-animate {
-  animation: slideInUp 0.4s ease-out;
-}
-</style>

--- a/Homassy.Web/app/components/ShoppingListItemCard.vue
+++ b/Homassy.Web/app/components/ShoppingListItemCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative rounded-2xl overflow-hidden card-animate" style="touch-action: pan-y" data-no-pull-refresh>
+  <div class="relative rounded-2xl overflow-hidden" style="touch-action: pan-y" data-no-pull-refresh>
     <!-- Swipe action layer (revealed behind the card while dragging) -->
     <div
       v-show="swipe.isSwiping.value"
@@ -955,20 +955,3 @@ const closeRestoreModal = () => {
   isRestoreModalOpen.value = false
 }
 </script>
-
-<style scoped>
-@keyframes slideInUp {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.card-animate {
-  animation: slideInUp 0.4s ease-out;
-}
-</style>

--- a/Homassy.Web/app/pages/calendar.vue
+++ b/Homassy.Web/app/pages/calendar.vue
@@ -146,22 +146,32 @@
               ref="scrollContainer"
               class="space-y-2 overflow-y-auto flex-1 min-h-0 lg:flex-none lg:max-h-[calc(100vh-8rem)]"
             >
-              <template v-for="(item, idx) in visibleItems" :key="item.kind + '-' + item.data.publicId + '-' + idx">
-                <CalendarEventCard
-                  v-if="item.kind === 'event'"
-                  :title="item.data.title"
-                  :event-type="item.data.eventType"
-                  :detail="item.data.detail"
-                  :color="item.data.color"
-                />
-                <CalendarActivityCard
-                  v-else-if="item.kind === 'activity'"
-                  :activity-type="item.data.activityType"
-                  :user-name="item.data.userName"
-                  :record-name="item.data.recordName"
-                  :timestamp="item.data.timestamp"
-                />
-              </template>
+              <!-- Only the cards belong in the AnimatedList: the load-more
+                   skeletons and the IntersectionObserver sentinel below must not
+                   be animated, and must not become keyed transition children.
+                   The scroll container itself stays a plain <div> because it owns
+                   ref="scrollContainer", which is passed to the observer as its
+                   root. Keying the list by the selected day makes a day switch a
+                   fresh staggered render instead of every old card bursting while
+                   every new one bubbles into the same space. -->
+              <AnimatedList :key="selectedDay ?? 'none'" class="space-y-2">
+                <template v-for="item in visibleItems" :key="item.uid">
+                  <CalendarEventCard
+                    v-if="item.kind === 'event'"
+                    :title="item.data.title"
+                    :event-type="item.data.eventType"
+                    :detail="item.data.detail"
+                    :color="item.data.color"
+                  />
+                  <CalendarActivityCard
+                    v-else
+                    :activity-type="item.data.activityType"
+                    :user-name="item.data.userName"
+                    :record-name="item.data.recordName"
+                    :timestamp="item.data.timestamp"
+                  />
+                </template>
+              </AnimatedList>
 
               <!-- Skeleton while loading more -->
               <template v-if="isLoadingMore">
@@ -225,8 +235,8 @@ interface CalActivity {
 }
 
 type DayItem =
-  | { kind: 'event'; data: CalEvent }
-  | { kind: 'activity'; data: CalActivity }
+  | { kind: 'event'; uid: string; data: CalEvent }
+  | { kind: 'activity'; uid: string; data: CalActivity }
 
 const toLocalDate = (date: Date): string => {
   const y = date.getFullYear()
@@ -371,12 +381,12 @@ const selectedDayItems = computed((): DayItem[] => {
   if (!selectedDay.value) return []
 
   const events: DayItem[] = (eventsByDate.value[selectedDay.value] ?? [])
-    .map(e => ({ kind: 'event' as const, data: e }))
+    .map(e => ({ kind: 'event' as const, uid: `event-${e.publicId}-${e.startAt}-${e.title}`, data: e }))
 
   const activities: DayItem[] = (activitiesByDate.value[selectedDay.value] ?? [])
-    .map(a => ({ kind: 'activity' as const, data: a }))
+    .map(a => ({ kind: 'activity' as const, uid: `activity-${a.publicId}`, data: a }))
 
-  return [...events, ...activities].sort((a, b) => {
+  const merged = [...events, ...activities].sort((a, b) => {
     const aAllDay = a.kind === 'event' && a.data.isAllDay
     const bAllDay = b.kind === 'event' && b.data.isAllDay
     if (aAllDay !== bAllDay) return aAllDay ? -1 : 1
@@ -384,6 +394,21 @@ const selectedDayItems = computed((): DayItem[] => {
     const tb = b.kind === 'event' ? b.data.startAt : b.data.timestamp
     return tb.localeCompare(ta)
   })
+
+  // Events synthesised from an iCal feed all carry their *calendar's* PublicId,
+  // so two feed entries on the same day can produce the same uid. Suffix the
+  // duplicates so the keys stay unique; byte-identical entries are visually
+  // interchangeable, so which one keeps the bare uid does not matter. Unlike the
+  // old index-based key this one does not churn nodes when the list is re-sorted
+  // or extended, which is what the list transition needs.
+  const seen = new Map<string, number>()
+  for (const item of merged) {
+    const n = seen.get(item.uid) ?? 0
+    seen.set(item.uid, n + 1)
+    if (n > 0) item.uid = `${item.uid}#${n}`
+  }
+
+  return merged
 })
 
 const visibleItems = computed(() =>

--- a/Homassy.Web/app/pages/products/index.vue
+++ b/Homassy.Web/app/pages/products/index.vue
@@ -169,27 +169,33 @@
       :is-ready="isReady"
     />
 
-    <!-- Loading State -->
-    <div v-if="isLoading" class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+    <!-- Loading State — first load only. A pull-to-refresh, a socket reconnect
+         or a filter change keeps the grid mounted (PullToRefreshIndicator gives
+         the feedback); swapping it out would remount every card and replay the
+         bubble animation, and would swallow the leave animation of a card
+         removed in the same tick. -->
+    <div v-if="isLoading && !hasLoaded" class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
       <USkeleton v-for="i in 8" :key="i" class="h-36 w-full rounded-lg" />
     </div>
 
-    <!-- No Results -->
-    <div v-else-if="filteredProducts.length === 0 && !isLoading" class="text-center py-12">
-      <UIcon name="i-lucide-package-search" class="h-16 w-16 mx-auto text-gray-400 mb-4" />
-      <p class="text-gray-500 dark:text-gray-400">{{ $t('pages.products.noResults') }}</p>
-    </div>
+    <template v-else>
+      <!-- No Results — rendered next to the (then empty) grid, never in place of it. -->
+      <div v-if="filteredProducts.length === 0 && !isLoading" class="text-center py-12">
+        <UIcon name="i-lucide-package-search" class="h-16 w-16 mx-auto text-gray-400 mb-4" />
+        <p class="text-gray-500 dark:text-gray-400">{{ $t('pages.products.noResults') }}</p>
+      </div>
 
-    <!-- Products Grid -->
-    <div v-else class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-      <DetailedProductCard
-        v-for="product in displayedProducts"
-        :key="product.publicId"
-        :product="product"
-        :search-query="searchQuery"
-        @select="openOverview"
-      />
-    </div>
+      <!-- Products Grid -->
+      <AnimatedList class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        <DetailedProductCard
+          v-for="product in displayedProducts"
+          :key="product.publicId"
+          :product="product"
+          :search-query="searchQuery"
+          @select="openOverview"
+        />
+      </AnimatedList>
+    </template>
 
     <!-- Sentinel for intersection observer -->
     <div v-if="hasMoreProducts" ref="sentinelRef" class="w-full min-h-[1px]">
@@ -274,6 +280,9 @@ const FILTERS_KEY = 'productsFilters'
 // State
 const allProducts = ref<InventoryGridProductInfo[]>([])
 const isLoading = ref(false)
+// Distinguishes the first load (skeletons) from a refetch (keep the grid mounted
+// so the bubble animation is not replayed for every card).
+const hasLoaded = ref(false)
 const searchQuery = ref('')
 const filtersOpen = ref(false)
 
@@ -569,6 +578,7 @@ const loadProducts = async () => {
     }
   } finally {
     isLoading.value = false
+    hasLoaded.value = true
   }
 }
 

--- a/Homassy.Web/app/pages/profile/automation/create.vue
+++ b/Homassy.Web/app/pages/profile/automation/create.vue
@@ -76,7 +76,7 @@
         </div>
 
         <!-- Product Grid -->
-        <div
+        <AnimatedList
           v-else
           class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4"
         >
@@ -88,7 +88,7 @@
             :is-selected="form.productPublicId === product.publicId"
             @select="onProductSelected"
           />
-        </div>
+        </AnimatedList>
 
         <!-- Inventory Item Sub-selection (for AutoConsume / NotifyOnly) -->
         <template v-if="form.actionType !== AutomationActionType.AddToShoppingList && form.actionType !== AutomationActionType.LowStockAddToShoppingList && form.productPublicId">

--- a/Homassy.Web/app/pages/profile/automation/index.vue
+++ b/Homassy.Web/app/pages/profile/automation/index.vue
@@ -53,41 +53,47 @@
     <!-- Content Section -->
     <div class="px-4 sm:px-8 lg:px-14 pb-6">
 
-      <!-- Loading State -->
-      <template v-if="loading">
+      <!-- Loading State — first load only. A refetch keeps the grid mounted;
+           swapping it out would remount every card and replay the bubble
+           animation. -->
+      <template v-if="loading && !hasLoaded">
         <div class="space-y-4">
           <USkeleton v-for="i in 4" :key="i" class="h-20 w-full rounded-lg" />
         </div>
       </template>
 
-      <!-- Empty State -->
-      <div v-else-if="automations.length === 0" class="rounded-lg p-12 text-center">
-        <UIcon name="i-lucide-timer" class="h-16 w-16 text-gray-400 mx-auto mb-4" />
-        <p class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">
-          {{ $t('profile.automation.noAutomations') }}
-        </p>
-        <p class="text-gray-600 dark:text-gray-400">
-          {{ $t('profile.automation.addFirstAutomation') }}
-        </p>
-      </div>
+      <template v-else>
+        <!-- Both empty states render next to the (then empty) grid, never in
+             place of it: unmounting the grid replays the enter animation on the
+             way back and swallows the leave animation of the last card. -->
+        <div v-if="automations.length === 0" class="rounded-lg p-12 text-center">
+          <UIcon name="i-lucide-timer" class="h-16 w-16 text-gray-400 mx-auto mb-4" />
+          <p class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">
+            {{ $t('profile.automation.noAutomations') }}
+          </p>
+          <p class="text-gray-600 dark:text-gray-400">
+            {{ $t('profile.automation.addFirstAutomation') }}
+          </p>
+        </div>
 
-      <!-- No filter results -->
-      <div v-else-if="filteredAutomations.length === 0" class="rounded-lg p-12 text-center">
-        <UIcon name="i-lucide-search-x" class="h-12 w-12 text-gray-400 mx-auto mb-4" />
-        <p class="text-gray-600 dark:text-gray-400">
-          {{ $t('profile.automation.noFilterResults') }}
-        </p>
-      </div>
+        <!-- No filter results -->
+        <div v-else-if="filteredAutomations.length === 0" class="rounded-lg p-12 text-center">
+          <UIcon name="i-lucide-search-x" class="h-12 w-12 text-gray-400 mx-auto mb-4" />
+          <p class="text-gray-600 dark:text-gray-400">
+            {{ $t('profile.automation.noFilterResults') }}
+          </p>
+        </div>
 
-      <!-- Automation Rules List -->
-      <div v-else class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-        <DataAutomationCard
-          v-for="automation in filteredAutomations"
-          :key="automation.publicId"
-          :automation="automation"
-          @deleted="handleCardDeleted"
-        />
-      </div>
+        <!-- Automation Rules List -->
+        <AnimatedList class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          <DataAutomationCard
+            v-for="automation in filteredAutomations"
+            :key="automation.publicId"
+            :automation="automation"
+            @deleted="handleCardDeleted"
+          />
+        </AnimatedList>
+      </template>
     </div>
   </div>
 </template>
@@ -115,6 +121,9 @@ useFabActions(() => [
 
 // State
 const loading = ref(true)
+// Distinguishes the first load (skeletons) from a refetch (keep the grid mounted
+// so the bubble animation is not replayed for every card).
+const hasLoaded = ref(false)
 const automations = ref<AutomationResponse[]>([])
 
 // Filter state
@@ -225,6 +234,7 @@ async function loadAutomations() {
     console.error('Failed to load automations:', error)
   } finally {
     loading.value = false
+    hasLoaded.value = true
   }
 }
 

--- a/Homassy.Web/app/pages/profile/external-calendars.vue
+++ b/Homassy.Web/app/pages/profile/external-calendars.vue
@@ -65,8 +65,12 @@
       </div>
 
       <!-- Calendar list -->
-      <div v-if="externalCalendars.length > 0" class="space-y-2">
-        <template v-for="cal in externalCalendars" :key="cal.publicId">
+      <AnimatedList v-if="externalCalendars.length > 0" class="space-y-2">
+        <!-- One stable wrapper element per calendar: the card and the inline edit
+             form swap *inside* it, so toggling edit mode is not read as this card
+             leaving and a different item entering (they are different vnode types
+             under the same key, which would otherwise unmount + mount). -->
+        <div v-for="cal in externalCalendars" :key="cal.publicId">
           <DataExternalCalendarCard
             v-if="editingCalId !== cal.publicId"
             :calendar="cal"
@@ -110,8 +114,8 @@
               </UButton>
             </div>
           </div>
-        </template>
-      </div>
+        </div>
+      </AnimatedList>
       <div v-else class="text-sm text-gray-400 dark:text-gray-500 py-2">
         {{ $t('profile.family.externalCalendars.empty') }}
       </div>

--- a/Homassy.Web/app/pages/profile/products.vue
+++ b/Homassy.Web/app/pages/profile/products.vue
@@ -78,36 +78,42 @@
       :is-ready="isReady"
     />
 
-    <!-- Loading State -->
-    <template v-if="loading">
+    <!-- Loading State — first load only. A pull-to-refresh keeps the grid
+         mounted (PullToRefreshIndicator gives the feedback); swapping it out
+         would remount every card and replay the bubble animation. -->
+    <template v-if="loading && !hasLoaded">
       <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
         <USkeleton v-for="i in 12" :key="i" class="h-48 w-full rounded-lg" />
       </div>
     </template>
 
-    <!-- Empty State -->
-    <div v-else-if="filteredProducts.length === 0" class="rounded-lg p-12 text-center">
-      <UIcon name="i-lucide-package" class="h-16 w-16 text-gray-400 mx-auto mb-4" />
-      <p class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">
-        {{ hasActiveQuery ? $t('pages.products.noResults') : 'Nincsenek termékek' }}
-      </p>
-      <p class="text-gray-600 dark:text-gray-400">
-        {{ hasActiveQuery ? 'Próbálj meg más keresési feltételt' : 'Adj hozzá termékeket a kezdéshez' }}
-      </p>
-    </div>
+    <template v-else>
+      <!-- Empty State — rendered next to the (then empty) grid, never in place
+           of it: unmounting the grid replays the enter animation on the way back
+           and swallows the leave animation of the last card removed. -->
+      <div v-if="filteredProducts.length === 0" class="rounded-lg p-12 text-center">
+        <UIcon name="i-lucide-package" class="h-16 w-16 text-gray-400 mx-auto mb-4" />
+        <p class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">
+          {{ hasActiveQuery ? $t('pages.products.noResults') : 'Nincsenek termékek' }}
+        </p>
+        <p class="text-gray-600 dark:text-gray-400">
+          {{ hasActiveQuery ? 'Próbálj meg más keresési feltételt' : 'Adj hozzá termékeket a kezdéshez' }}
+        </p>
+      </div>
 
-    <!-- Products Grid -->
-    <div v-else class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
-      <DataProductCard
-        v-for="product in filteredProducts"
-        :key="product.publicId"
-        :product="product"
-        :search-query="searchQuery"
-        @select="openOverview"
-        @edit="openEditDrawer"
-        @deleted="onDeleted"
-      />
-    </div>
+      <!-- Products Grid -->
+      <AnimatedList class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
+        <DataProductCard
+          v-for="product in filteredProducts"
+          :key="product.publicId"
+          :product="product"
+          :search-query="searchQuery"
+          @select="openOverview"
+          @edit="openEditDrawer"
+          @deleted="onDeleted"
+        />
+      </AnimatedList>
+    </template>
     </div>
 
   <!-- Create / edit bottom sheet -->
@@ -156,6 +162,9 @@ const { formatProductCategory } = useEnumLabel()
 const { pullDistance, isPulling, isRefreshing, isReady } = usePullToRefresh(() => loadProducts())
 
 const loading = ref(true)
+// Distinguishes the first load (skeletons) from a refetch (keep the grid mounted
+// so the bubble animation is not replayed for every card).
+const hasLoaded = ref(false)
 const products = ref<ProductInfo[]>([])
 const searchQuery = ref('')
 
@@ -188,6 +197,7 @@ async function loadProducts() {
     console.error('Failed to load products:', error)
   } finally {
     loading.value = false
+    hasLoaded.value = true
   }
 }
 

--- a/Homassy.Web/app/pages/profile/shopping-locations.vue
+++ b/Homassy.Web/app/pages/profile/shopping-locations.vue
@@ -43,36 +43,42 @@
       :is-ready="isReady"
     />
 
-    <!-- Loading State -->
-    <template v-if="loading">
+    <!-- Loading State — first load only. A pull-to-refresh keeps the grid
+         mounted (PullToRefreshIndicator gives the feedback); swapping it out
+         would remount every card and replay the bubble animation. -->
+    <template v-if="loading && !hasLoaded">
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <USkeleton v-for="i in 6" :key="i" class="h-32 w-full rounded-lg" />
       </div>
     </template>
 
-    <!-- Empty State -->
-    <div v-else-if="filteredLocations.length === 0" class="rounded-lg p-12 text-center">
-      <UIcon name="i-lucide-shopping-cart" class="h-16 w-16 text-gray-400 mx-auto mb-4" />
-      <p class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">
-        {{ hasActiveQuery ? $t('profile.shoppingLocations.noResults') : $t('profile.shoppingLocations.noLocations') }}
-      </p>
-      <p class="text-gray-600 dark:text-gray-400">
-        {{ hasActiveQuery ? $t('profile.shoppingLocations.tryDifferentSearch') : $t('profile.shoppingLocations.addFirstLocation') }}
-      </p>
-    </div>
+    <template v-else>
+      <!-- Empty State — rendered next to the (then empty) grid, never in place
+           of it: unmounting the grid replays the enter animation on the way back
+           and swallows the leave animation of the last card removed. -->
+      <div v-if="filteredLocations.length === 0" class="rounded-lg p-12 text-center">
+        <UIcon name="i-lucide-shopping-cart" class="h-16 w-16 text-gray-400 mx-auto mb-4" />
+        <p class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">
+          {{ hasActiveQuery ? $t('profile.shoppingLocations.noResults') : $t('profile.shoppingLocations.noLocations') }}
+        </p>
+        <p class="text-gray-600 dark:text-gray-400">
+          {{ hasActiveQuery ? $t('profile.shoppingLocations.tryDifferentSearch') : $t('profile.shoppingLocations.addFirstLocation') }}
+        </p>
+      </div>
 
-    <!-- Locations Grid -->
-    <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      <DataShoppingLocationCard
-        v-for="location in filteredLocations"
-        :key="location.publicId"
-        :location="location"
-        :search-query="searchQuery"
-        @select="openOverview"
-        @edit="openEditDrawer"
-        @deleted="onDeleted"
-      />
-    </div>
+      <!-- Locations Grid -->
+      <AnimatedList class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <DataShoppingLocationCard
+          v-for="location in filteredLocations"
+          :key="location.publicId"
+          :location="location"
+          :search-query="searchQuery"
+          @select="openOverview"
+          @edit="openEditDrawer"
+          @deleted="onDeleted"
+        />
+      </AnimatedList>
+    </template>
     </div>
 
   <!-- Create / edit bottom sheet -->
@@ -112,6 +118,9 @@ useFabActions(() => [
 const { pullDistance, isPulling, isRefreshing, isReady } = usePullToRefresh(loadLocations)
 
 const loading = ref(true)
+// Distinguishes the first load (skeletons) from a refetch (keep the grid mounted
+// so the bubble animation is not replayed for every card).
+const hasLoaded = ref(false)
 const locations = ref<ShoppingLocationInfo[]>([])
 const searchQuery = ref('')
 
@@ -230,6 +239,7 @@ async function loadLocations() {
     console.error('Failed to load shopping locations:', error)
   } finally {
     loading.value = false
+    hasLoaded.value = true
   }
 }
 

--- a/Homassy.Web/app/pages/profile/storage-locations.vue
+++ b/Homassy.Web/app/pages/profile/storage-locations.vue
@@ -36,36 +36,42 @@
       :is-ready="isReady"
     />
 
-    <!-- Loading State -->
-    <template v-if="loading">
+    <!-- Loading State — first load only. A pull-to-refresh keeps the grid
+         mounted (PullToRefreshIndicator gives the feedback); swapping it out
+         would remount every card and replay the bubble animation. -->
+    <template v-if="loading && !hasLoaded">
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <USkeleton v-for="i in 6" :key="i" class="h-32 w-full rounded-lg" />
       </div>
     </template>
 
-    <!-- Empty State -->
-    <div v-else-if="filteredLocations.length === 0" class="rounded-lg p-12 text-center">
-      <UIcon name="i-lucide-warehouse" class="h-16 w-16 text-gray-400 mx-auto mb-4" />
-      <p class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">
-        {{ hasActiveQuery ? $t('profile.storageLocations.noResults') : $t('profile.storageLocations.noLocations') }}
-      </p>
-      <p class="text-gray-600 dark:text-gray-400">
-        {{ hasActiveQuery ? $t('profile.storageLocations.tryDifferentSearch') : $t('profile.storageLocations.addFirstLocation') }}
-      </p>
-    </div>
+    <template v-else>
+      <!-- Empty State — rendered next to the (then empty) grid, never in place
+           of it: unmounting the grid replays the enter animation on the way back
+           and swallows the leave animation of the last card removed. -->
+      <div v-if="filteredLocations.length === 0" class="rounded-lg p-12 text-center">
+        <UIcon name="i-lucide-warehouse" class="h-16 w-16 text-gray-400 mx-auto mb-4" />
+        <p class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">
+          {{ hasActiveQuery ? $t('profile.storageLocations.noResults') : $t('profile.storageLocations.noLocations') }}
+        </p>
+        <p class="text-gray-600 dark:text-gray-400">
+          {{ hasActiveQuery ? $t('profile.storageLocations.tryDifferentSearch') : $t('profile.storageLocations.addFirstLocation') }}
+        </p>
+      </div>
 
-    <!-- Locations Grid -->
-    <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      <DataStorageLocationCard
-        v-for="location in filteredLocations"
-        :key="location.publicId"
-        :location="location"
-        :search-query="searchQuery"
-        @select="openOverview"
-        @edit="openEditDrawer"
-        @deleted="onDeleted"
-      />
-    </div>
+      <!-- Locations Grid -->
+      <AnimatedList class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <DataStorageLocationCard
+          v-for="location in filteredLocations"
+          :key="location.publicId"
+          :location="location"
+          :search-query="searchQuery"
+          @select="openOverview"
+          @edit="openEditDrawer"
+          @deleted="onDeleted"
+        />
+      </AnimatedList>
+    </template>
     </div>
 
   <!-- Create / edit bottom sheet -->
@@ -105,6 +111,9 @@ useFabActions(() => [
 const { pullDistance, isPulling, isRefreshing, isReady } = usePullToRefresh(loadStorageLocations)
 
 const loading = ref(true)
+// Distinguishes the first load (skeletons) from a refetch (keep the grid mounted
+// so the bubble animation is not replayed for every card).
+const hasLoaded = ref(false)
 const locations = ref<StorageLocationInfo[]>([])
 const searchQuery = ref('')
 
@@ -196,6 +205,7 @@ async function loadStorageLocations() {
     console.error('Failed to load storage locations:', error)
   } finally {
     loading.value = false
+    hasLoaded.value = true
   }
 }
 

--- a/Homassy.Web/app/pages/shopping-lists/index.vue
+++ b/Homassy.Web/app/pages/shopping-lists/index.vue
@@ -113,8 +113,11 @@
           {{ $t('pages.shoppingLists.nearby.searching') }}
         </p>
       </div>
-      <!-- Loading State -->
-      <div v-if="isLoadingDetails" class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+      <!-- Loading State — only while there is nothing to show yet. A refetch of
+           an already-open list (showPurchased toggle, socket reconnect,
+           pull-to-refresh) keeps the grid mounted, so the bubble animation is
+           not replayed for every card. -->
+      <div v-if="isLoadingDetails && !currentListDetails" class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
         <USkeleton class="h-48 w-full" />
         <USkeleton class="h-48 w-full" />
         <USkeleton class="h-48 w-full" />
@@ -143,36 +146,42 @@
         />
       </div>
 
-      <!-- Empty: No Items in List -->
-      <div v-else-if="currentListDetails && currentListDetails.items.length === 0" class="text-center py-12">
-        <UIcon name="i-lucide-package-open" class="h-16 w-16 mx-auto text-gray-400 mb-4" />
-        <p class="text-gray-500 dark:text-gray-400">
-          {{ $t('pages.shoppingLists.noItemsInList') }}
-        </p>
-      </div>
+      <!-- A list is open -->
+      <template v-else>
+        <!-- Both empty states render next to the (then empty) grid, never in
+             place of it: unmounting the grid replays the enter animation on the
+             way back and swallows the leave animation of the last item removed. -->
+        <!-- Empty: No Items in List -->
+        <div v-if="currentListDetails && currentListDetails.items.length === 0" class="text-center py-12">
+          <UIcon name="i-lucide-package-open" class="h-16 w-16 mx-auto text-gray-400 mb-4" />
+          <p class="text-gray-500 dark:text-gray-400">
+            {{ $t('pages.shoppingLists.noItemsInList') }}
+          </p>
+        </div>
 
-      <!-- Empty: No Search Results -->
-      <div v-else-if="filteredItems.length === 0" class="text-center py-12">
-        <p class="text-gray-500 dark:text-gray-400">
-          {{ $t('pages.shoppingLists.noSearchResults') }}
-        </p>
-      </div>
+        <!-- Empty: No Search Results -->
+        <div v-else-if="filteredItems.length === 0" class="text-center py-12">
+          <p class="text-gray-500 dark:text-gray-400">
+            {{ $t('pages.shoppingLists.noSearchResults') }}
+          </p>
+        </div>
 
-      <!-- Items Grid -->
-      <div v-else class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-        <ShoppingListItemCard
-          v-for="item in filteredItems"
-          :key="item.publicId"
-          :item="item"
-          :search-query="searchQuery"
-          :at-current-location="isItemAtCurrentLocation(item)"
-          :similar-type-at-current-location="isItemSimilarTypeHere(item)"
-          :shopping-locations="allShoppingLocations"
-          :current-store="currentStoreForItem(item)"
-          @refresh="handleItemRefresh"
-          @deleted="handleItemRefresh"
-        />
-      </div>
+        <!-- Items Grid -->
+        <AnimatedList class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          <ShoppingListItemCard
+            v-for="item in filteredItems"
+            :key="item.publicId"
+            :item="item"
+            :search-query="searchQuery"
+            :at-current-location="isItemAtCurrentLocation(item)"
+            :similar-type-at-current-location="isItemSimilarTypeHere(item)"
+            :shopping-locations="allShoppingLocations"
+            :current-store="currentStoreForItem(item)"
+            @refresh="handleItemRefresh"
+            @deleted="handleItemRefresh"
+          />
+        </AnimatedList>
+      </template>
     </div>
 
     <!-- Filter drawer (bottom sheet) -->
@@ -1316,6 +1325,10 @@ watch(selectedListId, (newId, oldId) => {
   notifiedLocationIds.value = new Set()
 
   if (newId) {
+    // Drop the previous list so the skeleton (not the wrong list's items) shows
+    // while the new one loads, and so the new list gets a fresh staggered render
+    // instead of every old card bursting as every new one bubbles in.
+    currentListDetails.value = null
     loadListDetails(newId)
     // Save to localStorage
     localStorage.setItem(LAST_SELECTED_LIST_KEY, newId)


### PR DESCRIPTION
Closes #65

Items appeared and disappeared instantly in every list and grid. They now pop into place, burst when removed, and the surrounding cards glide into the gap — identically whether the change was made on this device or arrived over SignalR from another family member.

## Approach

The transition lives in one place: `.bubble-*` in `app/assets/css/main.css` (unlayered, next to the existing page transition, with a `prefers-reduced-motion` override), driven through a new `AnimatedList` component used by all ten call sites.

Three decisions worth knowing while reviewing:

- **`AnimatedList` replaces each container element and inherits its classes** rather than nesting inside it. Tailwind v4 emits `space-y-*` as a direct-child selector and grid participation is direct-child too, so a wrapper *inside* a grid would collapse the list into one column, and inside a stack it would zero out all spacing. The one exception is `calendar.vue`, where the container keeps `ref="scrollContainer"` (the IntersectionObserver root) and the transition is nested inside it, with the skeletons and sentinel deliberately left outside.
- **Leaving cards are pinned out of flow with measured inline geometry.** Out-of-flow is required or the survivors snap instead of gliding, but a bare `position: absolute` does not work here: an auto-placed absolutely positioned child of a CSS grid resolves against the grid's padding box, so it would jump to the top-left corner at content width. The snapshot is taken once per update, before anything is pinned — measuring per card would be wrong, because pinning reflows the grid and every later removal in the same batch would read a shifted cell.
- **Transition, not `@keyframes`.** The overshoot comes from the easing curve the FAB and swipe commit already use, and `transition: none` can actually be killed under reduced motion, which an animation cannot.

Only `transform` and `opacity` are animated, so it stays on the compositor. The first render of a list is staggered; later insertions are not, so infinite scroll and realtime arrivals come in immediately. Work is capped per update so a filter that drops dozens of cards does not composite dozens of layers at once.

## Why `.card-animate` had to go

Nine card components each carried their own copy of `@keyframes slideInUp` + `.card-animate`. They could not coexist with this: `TransitionGroup` detects FLIP support by cloning a child and comparing its computed animation and transition timings, so a 0.4s keyframe animation on the card root made it report no transform transition and **silently disabled the move animation entirely** — no warning. On top of that, CSS animations outrank the transition on the same properties, so the enter would have been invisible and then snapped.

Consequence for reviewers: a list that is *not* wrapped in `AnimatedList` no longer has an entry animation. That is why `profile/automation/create.vue`'s product picker is included even though the issue does not list it — `SelectableProductCard` lost `.card-animate` too.

## Replay fixes

The issue requires that a full reload or a filter change not replay the animation for every card. The data flow was already fine (every SignalR handler patches in place, filtering is a computed over the same object references, a refetch reuses the same `publicId`s). The problem was structural: `isLoading` and the `length === 0` empty state each swapped the whole grid out via a sibling `v-if`, which remounts every card on the way back — and also *swallows* leave animations, since Vue skips them when the container is unmounting.

So skeletons now only replace a list on the genuine first load (`hasLoaded`), and empty states render alongside the grid instead of in place of it. This also improves refresh UX: the stale grid stays visible behind the pull-to-refresh indicator instead of being blanked.

## calendar.vue keys

The day list was keyed by array index, which churns nodes on any reorder. The index turned out to be load-bearing rather than sloppy: events synthesised from an iCal feed all carry their *calendar's* `PublicId`, so two entries on the same day collide. Replaced with a content-derived uid plus a suffix for genuine duplicates.

## Notes

- `eslint` is clean on every touched file, and `nuxi typecheck` reports the same 160 pre-existing errors before and after the change (verified against a stashed tree) — no new ones.
- Reduced motion degrades to instant, matching the existing `.page-*` precedent in the same file.
- `InventoryItemList` renders inside a drawer, so its stagger fires each time the sheet opens; pass `:stagger="false"` if that reads as busy against the sheet's own slide-in.
- Worth a look during review: how rapid-fire filtering *feels*, since the search inputs are undebounced and each keystroke produces a burst plus a move batch. Debouncing them was deliberately left out as a behaviour change outside this issue's scope; the per-update cap bounds the worst case.
