### PR TITLE
fix(logging): keep SQL statements out of service logs

### DIFF
--- a/Homassy.API/Extensions/SerilogExtensions.cs
+++ b/Homassy.API/Extensions/SerilogExtensions.cs
@@ -1,0 +1,69 @@
+using Serilog;
+using Serilog.Events;
+
+namespace Homassy.API.Extensions;
+
+/// <summary>
+/// Shared Serilog minimum level policy for every Homassy service.
+/// EF Core writes the full SQL text of every command to the
+/// <c>Microsoft.EntityFrameworkCore.Database.Command</c> category at Information level,
+/// so that category is kept at Warning unless SQL logging is explicitly switched on.
+/// This file is compiled into Homassy.Email as a link, so all services share one definition.
+/// </summary>
+public static class SerilogExtensions
+{
+    /// <summary>
+    /// Environment variable that raises EF Core back to Information (SQL statements visible).
+    /// Local debugging only – ignored when the service runs in the Production environment.
+    /// </summary>
+    public const string SqlLoggingEnvironmentVariable = "EFCORE_SQL_LOGGING";
+
+    /// <summary>
+    /// Applies the shared minimum levels. Every service must call this instead of
+    /// configuring <c>MinimumLevel</c> by hand, so no service can accidentally start
+    /// with SQL logging enabled.
+    /// </summary>
+    /// <param name="loggerConfiguration">The Serilog configuration being built.</param>
+    /// <param name="defaultLevel">Default level for application code.</param>
+    /// <param name="environmentName">
+    /// Host environment name. When null it is read from the environment variables
+    /// (falling back to Production, the safe default).
+    /// </param>
+    public static LoggerConfiguration UseHomassyMinimumLevels(
+        this LoggerConfiguration loggerConfiguration,
+        LogEventLevel defaultLevel = LogEventLevel.Information,
+        string? environmentName = null)
+    {
+        var efCoreLevel = IsSqlLoggingEnabled(environmentName)
+            ? LogEventLevel.Information
+            : LogEventLevel.Warning;
+
+        return loggerConfiguration
+            .MinimumLevel.Is(defaultLevel)
+            .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+            .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+            .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Warning)
+            .MinimumLevel.Override("Microsoft.EntityFrameworkCore", efCoreLevel)
+            .MinimumLevel.Override("System", LogEventLevel.Warning);
+    }
+
+    /// <summary>
+    /// True only when <see cref="SqlLoggingEnvironmentVariable"/> is set to a truthy value
+    /// and the service is not running in Production.
+    /// </summary>
+    private static bool IsSqlLoggingEnabled(string? environmentName)
+    {
+        var flag = Environment.GetEnvironmentVariable(SqlLoggingEnvironmentVariable);
+
+        if (!bool.TryParse(flag, out var enabled) || !enabled)
+        {
+            return false;
+        }
+
+        environmentName ??= Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
+            ?? Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT")
+            ?? Environments.Production;
+
+        return !string.Equals(environmentName, Environments.Production, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Homassy.API/Program.cs
+++ b/Homassy.API/Program.cs
@@ -23,12 +23,7 @@ using System.Text;
 using System.Text.Json;
 
 Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Debug()
-    .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
-    .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
-    .MinimumLevel.Override("Microsoft.AspNetCore.Authentication", LogEventLevel.Warning)
-    .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
-    .MinimumLevel.Override("System", LogEventLevel.Warning)
+    .UseHomassyMinimumLevels(LogEventLevel.Debug)
     .Enrich.FromLogContext()
     .WriteTo.Console(
         outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")

--- a/Homassy.API/Services/CLAUDE.md
+++ b/Homassy.API/Services/CLAUDE.md
@@ -9,10 +9,8 @@ Structured logging with console and file sinks:
 **Configuration:**
 ```csharp
 Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Debug()
-    .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
-    .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
-    .MinimumLevel.Override("Microsoft.EntityFrameworkCore", LogEventLevel.Warning)
+    .UseHomassyMinimumLevels(LogEventLevel.Debug)   // Extensions/SerilogExtensions.cs
+    .Enrich.FromLogContext()
     .WriteTo.Console(outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
     .WriteTo.File(
         path: "Logs/Homassy-.log",
@@ -27,6 +25,36 @@ Log.Logger = new LoggerConfiguration()
 - 14-day retention
 - Reduced verbosity for framework logs
 - Structured logging context
+
+#### Shared minimum levels (`Extensions/SerilogExtensions.cs`)
+
+`UseHomassyMinimumLevels()` defines the level policy **once** for every service
+(Homassy.API, Homassy.Notifications, and Homassy.Email — the latter compiles the same file
+as a link because it must not reference Homassy.API). Never set `MinimumLevel` by hand in a
+service: doing so is how a service starts leaking SQL again.
+
+| Category | Level |
+|----------|-------|
+| _default_ | caller-supplied (`Debug` in the API, `Information` in the other services) |
+| `Microsoft` | Information |
+| `Microsoft.AspNetCore` | Warning |
+| `Microsoft.AspNetCore.Authentication` | Warning |
+| `Microsoft.EntityFrameworkCore` | Warning |
+| `System` | Warning |
+
+EF Core logs the full SQL text of every command to
+`Microsoft.EntityFrameworkCore.Database.Command` at Information, so the `Warning` override is
+what keeps SQL statements — and the schema they expose — out of console and file logs.
+
+**Debug escape hatch:** set `EFCORE_SQL_LOGGING=true` to raise EF Core back to Information.
+It is ignored when the host environment is `Production`, so SQL can never surface there.
+
+```bash
+docker compose run --rm -e EFCORE_SQL_LOGGING=true homassy.notifications
+```
+
+Serilog is configured entirely in code — the `Logging:LogLevel` section of `appsettings*.json`
+has no effect and must not be reintroduced.
 
 **Usage:**
 ```csharp

--- a/Homassy.API/appsettings.Production.json
+++ b/Homassy.API/appsettings.Production.json
@@ -1,11 +1,4 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning",
-      "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
-    }
-  },
   "AllowedHosts": "*",
   "RateLimiting": {
     "GlobalMaxAttempts": "100",

--- a/Homassy.API/appsettings.example.json
+++ b/Homassy.API/appsettings.example.json
@@ -1,11 +1,4 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning",
-      "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
-    }
-  },
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5432;Database=homassy_db;Username=your_username;Password=your_password"

--- a/Homassy.Email/CLAUDE.md
+++ b/Homassy.Email/CLAUDE.md
@@ -455,15 +455,15 @@ Tests a live SMTP connection on every readiness probe call:
   },
   "InternalApi": {
     "ApiKey": "the-global-internal-api-key"
-  },
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
   }
 }
 ```
+
+> **Logging is configured in code, not in config.** `Program.cs` calls
+> `UseHomassyMinimumLevels()` from `Homassy.API/Extensions/SerilogExtensions.cs`, which is
+> compiled into this project as a **link** (see the `Compile Include` in the `.csproj`) so the
+> service shares the level policy without taking a project reference on Homassy.API.
+> A `Logging:LogLevel` section in `appsettings.json` would have no effect — don't add one.
 
 ### Configuration Keys
 

--- a/Homassy.Email/Homassy.Email.csproj
+++ b/Homassy.Email/Homassy.Email.csproj
@@ -7,6 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Shared Serilog level policy. Linked instead of referenced: Homassy.Email has no
+         database and must not take a project reference on Homassy.API (EF Core, Npgsql). -->
+    <Compile Include="..\Homassy.API\Extensions\SerilogExtensions.cs" Link="Extensions\SerilogExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="Templates\CodeEmail.html" />
     <EmbeddedResource Include="Templates\WeeklySummaryEmail.html" />
     <EmbeddedResource Include="Templates\AutomationNotificationEmail.html" />

--- a/Homassy.Email/Program.cs
+++ b/Homassy.Email/Program.cs
@@ -1,15 +1,14 @@
-﻿using Homassy.Email.Endpoints;
+﻿using Homassy.API.Extensions;
+using Homassy.Email.Endpoints;
 using Homassy.Email.HealthChecks;
 using Homassy.Email.Middleware;
 using Homassy.Email.Services;
 using Homassy.Email.Workers;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Serilog;
-using Serilog.Events;
 
 Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Information()
-    .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+    .UseHomassyMinimumLevels()
     .Enrich.FromLogContext()
     .WriteTo.Console()
     .CreateBootstrapLogger();
@@ -20,8 +19,7 @@ try
 
     var builder = WebApplication.CreateBuilder(args);
     builder.Host.UseSerilog((ctx, cfg) => cfg
-        .MinimumLevel.Information()
-        .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+        .UseHomassyMinimumLevels(environmentName: ctx.HostingEnvironment.EnvironmentName)
         .Enrich.FromLogContext()
         .WriteTo.Console());
 

--- a/Homassy.Migrator/Program.cs
+++ b/Homassy.Migrator/Program.cs
@@ -38,7 +38,9 @@ try
     // Set configuration for HomassyDbContext
     HomassyDbContext.SetConfiguration(configuration);
 
-    // Create DbContext
+    // Create DbContext. No logger factory is attached on purpose: EF Core then emits nothing,
+    // so no SQL statement text ends up in the migrator output. Progress is reported by the
+    // Console.WriteLine calls below (migration names only, never the statements themselves).
     var optionsBuilder = new DbContextOptionsBuilder<HomassyDbContext>();
     optionsBuilder.UseNpgsql(connectionString);
     await using var context = new HomassyDbContext(optionsBuilder.Options);

--- a/Homassy.Notifications/CLAUDE.md
+++ b/Homassy.Notifications/CLAUDE.md
@@ -227,6 +227,23 @@ Email) validates and sends the same value.
 }
 ```
 
+The service ships **no `appsettings.json`** — every value above comes from environment
+variables via Docker Compose (double-underscore notation, e.g. `ConnectionStrings__DefaultConnection`).
+
+### Logging levels
+
+Serilog is configured in code via `UseHomassyMinimumLevels()`
+(`Homassy.API/Extensions/SerilogExtensions.cs`, shared with the API and Email). It pins
+`Microsoft.EntityFrameworkCore` to `Warning`, so the six background workers do **not** dump the
+SQL of every polling cycle into `docker logs homassy-notifications`. Never set `MinimumLevel`
+by hand here.
+
+To see SQL locally, set `EFCORE_SQL_LOGGING=true` — it is ignored in the `Production` environment:
+
+```bash
+docker compose run --rm -e EFCORE_SQL_LOGGING=true homassy.notifications
+```
+
 ---
 
 ## Development Guidelines

--- a/Homassy.Notifications/Program.cs
+++ b/Homassy.Notifications/Program.cs
@@ -1,4 +1,5 @@
 ﻿using Homassy.API.Context;
+using Homassy.API.Extensions;
 using Homassy.Notifications.Endpoints;
 using Homassy.Notifications.HealthChecks;
 using Homassy.Notifications.Middleware;
@@ -7,11 +8,9 @@ using Homassy.Notifications.Workers;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
-using Serilog.Events;
 
 Log.Logger = new LoggerConfiguration()
-    .MinimumLevel.Information()
-    .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+    .UseHomassyMinimumLevels()
     .Enrich.FromLogContext()
     .WriteTo.Console()
     .CreateBootstrapLogger();
@@ -22,8 +21,7 @@ try
 
     var builder = WebApplication.CreateBuilder(args);
     builder.Host.UseSerilog((ctx, cfg) => cfg
-        .MinimumLevel.Information()
-        .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+        .UseHomassyMinimumLevels(environmentName: ctx.HostingEnvironment.EnvironmentName)
         .Enrich.FromLogContext()
         .WriteTo.Console());
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -14,8 +14,9 @@ services:
       - Jwt__AccessTokenExpirationMinutes=15
       - Jwt__RefreshTokenExpirationDays=7
       - Cors__AllowedOrigins__0=http://localhost:3000
-      - Logging__LogLevel__Default=Information
-      - Logging__LogLevel__Microsoft.AspNetCore=Warning
+      # Log levels come from UseHomassyMinimumLevels() in code; Logging__LogLevel__* has no effect.
+      # Uncomment to see EF Core SQL locally (ignored when ASPNETCORE_ENVIRONMENT=Production):
+      # - EFCORE_SQL_LOGGING=true
       - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
@@ -26,6 +27,8 @@ services:
   homassy.notifications:
     environment:
       - ConnectionStrings__DefaultConnection=${DB_CONNECTION_STRING_DOCKER}
+      # Uncomment to see EF Core SQL locally (ignored when ASPNETCORE_ENVIRONMENT=Production):
+      # - EFCORE_SQL_LOGGING=true
 
   homassy.web:
     environment:


### PR DESCRIPTION
Closes #69

EF Core logs the full text of every command to `Microsoft.EntityFrameworkCore.Database.Command` at Information level. `Homassy.Notifications` only overrode `Microsoft.AspNetCore`, so its six polling workers filled `docker logs homassy-notifications` with SQL and exposed the database schema.

## Changes

- **`Homassy.API/Extensions/SerilogExtensions.cs`** (new) — `UseHomassyMinimumLevels()` is the single definition of the level policy: `Microsoft.EntityFrameworkCore` → `Warning`, plus `Microsoft`, `Microsoft.AspNetCore`, `Microsoft.AspNetCore.Authentication` and `System`. Services call it instead of configuring `MinimumLevel` by hand, so a new service cannot start with SQL logging enabled.
- **`Homassy.API`, `Homassy.Notifications`, `Homassy.Email`** — use the shared policy. Notifications applies it to both the bootstrap logger and the `UseSerilog` configuration. Email has no project reference on `Homassy.API` (that would drag in EF Core and Npgsql for a service with no database), so it compiles the same file as a link.
- **Debug escape hatch** — `EFCORE_SQL_LOGGING=true` raises EF Core back to Information. It is ignored when the host environment is `Production`, and an unset environment defaults to `Production`, so the safe path is the default.
- **`Homassy.Migrator`** — already emits no SQL (no logger factory is attached to the `DbContext`); documented so it stays that way. Migration names are still printed.
- **Dead configuration removed** — Serilog is configured purely in code, so the `Logging:LogLevel` blocks in `appsettings.Production.json` / `appsettings.example.json` and the `Logging__LogLevel__*` variables in `docker-compose.override.yml` had no effect and are gone. The compose files instead carry a commented `EFCORE_SQL_LOGGING` line.
- **Docs** — `Homassy.API/Services/CLAUDE.md`, `Homassy.Notifications/CLAUDE.md`, `Homassy.Email/CLAUDE.md` describe the shared policy and the escape hatch.

## Verification

Stack started, workers exercised:

| Target | `Executed DbCommand` occurrences |
|---|---|
| `docker logs homassy-notifications` | 0 |
| `docker logs homassy-api` | 0 |
| `docker logs homassy-email` | 0 |
| `Homassy.API/Logs/Homassy-*.log` | 0 |
| notifications with `EFCORE_SQL_LOGGING=true` (Development) | 5 — hatch works |
| notifications with the same flag and `ASPNETCORE_ENVIRONMENT=Production` | 0 — ignored in production |

Worker start/stop messages, automation and weekly-summary checks, and HTTP request logs are unchanged. All four service projects build without errors.
