### PR TITLE
fix(product): reject deletion of global products

### DIFF
--- a/Homassy.API/Constants/ErrorCodeDescriptions.cs
+++ b/Homassy.API/Constants/ErrorCodeDescriptions.cs
@@ -38,6 +38,7 @@ public static class ErrorCodeDescriptions
         [ErrorCodes.ProductNotFound] = "Product not found.",
         [ErrorCodes.ProductAccessDenied] = "Access denied to this product.",
         [ErrorCodes.ProductInventoryNotFound] = "Product inventory item not found.",
+        [ErrorCodes.ProductDeletionNotAllowed] = "Products are shared by every family, so they cannot be deleted. Remove your own inventory items instead.",
 
         // Location Errors
         [ErrorCodes.LocationNotFound] = "Location not found.",

--- a/Homassy.API/Controllers/CLAUDE.md
+++ b/Homassy.API/Controllers/CLAUDE.md
@@ -91,7 +91,7 @@ Manages product catalog and inventory (all endpoints require `[Authorize]`).
 | GET | `/` | Get all products |
 | POST | `/` | Create new product |
 | PUT | `/{productPublicId}` | Update product |
-| DELETE | `/{productPublicId}` | Delete product |
+| DELETE | `/{productPublicId}` | Always rejected with **403** `PRODUCT-0004` — products are global |
 | POST | `/{productPublicId}/favorite` | Toggle favorite status |
 | GET | `/{productPublicId}/detailed` | Get detailed product info with inventory |
 | GET | `/detailed` | Get all detailed products for user |
@@ -100,6 +100,7 @@ Manages product catalog and inventory (all endpoints require `[Authorize]`).
 - Product customization per user (favorites, notes)
 - Inventory tracking with purchase info and consumption logs
 - Family-shared products support
+- **Products are never deletable through the API**: a `Product` row is global (only `ProductCustomization` is family-scoped), so deleting one would remove it — and its inventory items — for every family. `DELETE /{productPublicId}` rejects with 403 `PRODUCT-0004`; `ProductFunctions.DeleteProductAsync` remains for maintenance use only. Users drop a product from their own view by deleting their inventory items or their customization.
 
 **Realtime (SignalR):**
 - Hub at `/hubs/inventory` (`InventoryHub`, `[Authorize]`) — same Kratos-cookie-on-handshake auth as the shopping-list hub

--- a/Homassy.API/Controllers/ProductController.cs
+++ b/Homassy.API/Controllers/ProductController.cs
@@ -81,18 +81,17 @@ namespace Homassy.API.Controllers
         }
 
         /// <summary>
-        /// Deletes a product and all its inventory items.
+        /// Always rejects: products live in a shared, global namespace, so deleting one would
+        /// remove it (and the matching inventory items) for every family using it. Users remove
+        /// their own inventory items or their product customization instead.
         /// </summary>
         [HttpDelete("{productPublicId}")]
         [MapToApiVersion(1.0)]
-        [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status200OK)]
-        [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> DeleteProduct(Guid productPublicId, CancellationToken cancellationToken)
+        [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status403Forbidden)]
+        public IActionResult DeleteProduct(Guid productPublicId)
         {
-            await new ProductFunctions().DeleteProductAsync(productPublicId, cancellationToken);
-
-            Log.Information($"Product {productPublicId} deleted successfully");
-            return Ok(ApiResponse.SuccessResponse());
+            Log.Information($"Rejected delete request for shared product {productPublicId}");
+            return StatusCode(403, ApiResponse.ErrorResponse(ErrorCodes.ProductDeletionNotAllowed));
         }
 
         /// <summary>

--- a/Homassy.API/Enums/ErrorCode.cs
+++ b/Homassy.API/Enums/ErrorCode.cs
@@ -35,6 +35,7 @@ public static class ErrorCodes
     public const string ProductNotFound = "PRODUCT-0001";
     public const string ProductAccessDenied = "PRODUCT-0002";
     public const string ProductInventoryNotFound = "PRODUCT-0003";
+    public const string ProductDeletionNotAllowed = "PRODUCT-0004";
     #endregion
 
     #region Location Errors (LOCATION-0xxx)

--- a/Homassy.API/Functions/ProductFunctions.cs
+++ b/Homassy.API/Functions/ProductFunctions.cs
@@ -748,6 +748,11 @@ namespace Homassy.API.Functions
             }
         }
 
+        /// <summary>
+        /// Deletes a product for every family that uses it, disabling automations and detaching shopping
+        /// list items that reference it. Maintenance/administrative use only — products are global, so
+        /// this is deliberately not reachable through the public API surface (see ProductController.DeleteProduct).
+        /// </summary>
         public async Task DeleteProductAsync(Guid productPublicId, CancellationToken cancellationToken = default)
         {
             var userId = SessionInfo.GetUserId();

--- a/Homassy.Tests/Integration/ProductControllerTests.cs
+++ b/Homassy.Tests/Integration/ProductControllerTests.cs
@@ -230,12 +230,12 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
     }
 
     [Fact]
-    public async Task DeleteProduct_NonExistent_ReturnsNotFound()
+    public async Task DeleteProduct_Authenticated_ReturnsForbidden()
     {
         string? testEmail = null;
         try
         {
-            var (email, auth) = await _authHelper.CreateAndAuthenticateUserAsync("prod-del-notfound");
+            var (email, auth) = await _authHelper.CreateAndAuthenticateUserAsync("prod-del-forbidden");
             testEmail = email;
             _authHelper.SetAuthToken(auth.AccessToken);
 
@@ -245,7 +245,9 @@ public class ProductControllerTests : IClassFixture<HomassyWebApplicationFactory
             _output.WriteLine($"Status: {response.StatusCode}");
             _output.WriteLine($"Response: {responseBody}");
 
-            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            // Products are global: deletion is rejected outright, never attempted
+            Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+            Assert.Contains(ErrorCodes.ProductDeletionNotAllowed, responseBody);
         }
         finally
         {

--- a/Homassy.Web/app/components/DataProductCard.vue
+++ b/Homassy.Web/app/components/DataProductCard.vue
@@ -1,16 +1,13 @@
 <template>
   <div class="relative rounded-2xl overflow-hidden" style="touch-action: pan-y" data-no-pull-refresh>
-    <!-- Swipe action layer -->
+    <!-- Swipe action layer (edit only — products are global and cannot be deleted) -->
     <div
-      v-show="swipe.isSwiping.value"
+      v-show="swipe.isSwiping.value && swipe.direction.value === 'right'"
       aria-hidden="true"
-      class="absolute inset-0 rounded-2xl flex items-center justify-between px-4"
-      :class="swipe.direction.value === 'left' ? 'bg-error-500 dark:bg-error-600' : 'bg-primary-500 dark:bg-primary-600'"
+      class="absolute inset-0 rounded-2xl flex items-center px-4 bg-primary-500 dark:bg-primary-600"
     >
       <UIcon name="i-lucide-pencil" class="h-5 w-5 text-white transition-transform duration-150"
         :class="[swipe.direction.value === 'right' ? 'opacity-100' : 'opacity-0', swipe.progress.value >= 1 ? 'scale-125' : '']" />
-      <UIcon name="i-lucide-trash-2" class="h-5 w-5 text-white transition-transform duration-150"
-        :class="[swipe.direction.value === 'left' ? 'opacity-100' : 'opacity-0', swipe.progress.value >= 1 ? 'scale-125' : '']" />
     </div>
 
     <!-- Card surface (no image — data opens on click, like the inventory card) -->
@@ -49,32 +46,12 @@
         </div>
       </div>
     </div>
-
-    <!-- Delete confirmation -->
-    <AppDrawer :open="isDeleteModalOpen" :title="$t('pages.products.details.deleteProduct')" icon="i-lucide-trash-2" fit="content" @update:open="(v) => { isDeleteModalOpen = v }">
-      <p class="text-sm text-muted">{{ $t('pages.products.details.deleteProductModal.warning') }}</p>
-      <div class="space-y-2">
-        <div>
-          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ $t('common.name') }}:</span>
-          <span class="text-sm ml-2">{{ product.name }}</span>
-        </div>
-        <div v-if="product.brand">
-          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ $t('pages.addProduct.form.brand') }}:</span>
-          <span class="text-sm ml-2">{{ product.brand }}</span>
-        </div>
-      </div>
-      <template #footer>
-        <UButton :label="$t('common.cancel')" color="neutral" variant="outline" @click="() => { isDeleteModalOpen = false }" />
-        <UButton :label="$t('common.delete')" color="error" :loading="isDeleting" @click="handleDelete" />
-      </template>
-    </AppDrawer>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import type { ProductInfo } from '~/types/product'
-import { useProductsApi } from '~/composables/api/useProductsApi'
 import { useEnumLabel } from '~/composables/useEnumLabel'
 
 const props = withDefaults(defineProps<{
@@ -89,23 +66,16 @@ const props = withDefaults(defineProps<{
 const emit = defineEmits<{
   select: [publicId: string]
   edit: [product: ProductInfo]
-  deleted: [publicId: string]
 }>()
 
-const { t } = useI18n()
-const toast = useToast()
-const { deleteProduct } = useProductsApi()
 const { formatProductCategory } = useEnumLabel()
 const { highlightText } = useSearchHighlight()
 
-const isDeleteModalOpen = ref(false)
-const isDeleting = ref(false)
-
 const cardEl = ref<HTMLElement | null>(null)
+// Only edit (right). Products are global master data — deleting one would remove it for every
+// family, so removal happens per family through the inventory items instead.
 const swipe = useSwipeActions(cardEl, {
-  onSwipeLeft: () => { isDeleteModalOpen.value = true },
-  onSwipeRight: () => emit('edit', props.product),
-  disabled: () => isDeleteModalOpen.value || isDeleting.value
+  onSwipeRight: () => emit('edit', props.product)
 })
 
 const cardBorderClass = computed(() => {
@@ -119,19 +89,5 @@ function handleCardClick(event: MouseEvent) {
   const target = event.target as HTMLElement
   if (target.closest('a, button')) return
   emit('select', props.product.publicId)
-}
-
-async function handleDelete() {
-  isDeleting.value = true
-  try {
-    await deleteProduct(props.product.publicId)
-    isDeleteModalOpen.value = false
-    emit('deleted', props.product.publicId)
-  } catch (error) {
-    console.error('Failed to delete product:', error)
-    toast.add({ title: t('common.error'), description: t('pages.products.details.deleteProductModal.deleteFailed'), color: 'error' })
-  } finally {
-    isDeleting.value = false
-  }
 }
 </script>

--- a/Homassy.Web/app/components/InventoryItemList.vue
+++ b/Homassy.Web/app/components/InventoryItemList.vue
@@ -18,6 +18,12 @@
       />
     </div>
 
+    <!-- Products are global master data: the only family-scoped removal is the inventory item -->
+    <p v-if="items.length > 0" class="flex items-start gap-2 text-xs text-muted">
+      <UIcon name="i-lucide-info" class="h-3.5 w-3.5 shrink-0 mt-0.5 text-primary-500" />
+      <span>{{ $t('pages.products.details.sharedProductHint') }}</span>
+    </p>
+
     <!-- Empty state -->
     <div v-if="items.length === 0" class="text-center py-8 text-gray-500 dark:text-gray-400">
       {{ $t('pages.products.details.noInventoryItems') }}

--- a/Homassy.Web/app/composables/api/useProductsApi.ts
+++ b/Homassy.Web/app/composables/api/useProductsApi.ts
@@ -114,19 +114,6 @@ export const useProductsApi = () => {
   }
 
   /**
-   * Delete product
-   */
-  const deleteProduct = async (productPublicId: string) => {
-    const result = await client.delete(
-      `/api/v1/Product/${productPublicId}`
-    )
-    if (result.success) {
-      eventBus.emit('product:deleted')
-    }
-    return result
-  }
-
-  /**
    * Toggle product favorite status
    */
   const toggleFavorite = async (productPublicId: string) => {
@@ -342,7 +329,6 @@ export const useProductsApi = () => {
     getProductHistory,
     createProduct,
     updateProduct,
-    deleteProduct,
     toggleFavorite,
     createMultipleProducts,
     uploadProductImage,

--- a/Homassy.Web/app/composables/useSwipeActions.ts
+++ b/Homassy.Web/app/composables/useSwipeActions.ts
@@ -119,6 +119,8 @@ export const useSwipeActions = (
       offset = Math.sign(dx) * (t + overshoot * 0.25)
     }
     offset = Math.max(-maxDrag, Math.min(maxDrag, offset))
+    // A direction without a handler does not drag at all — no action layer is revealed for it
+    if ((offset < 0 && !options.onSwipeLeft) || (offset > 0 && !options.onSwipeRight)) offset = 0
     translateX.value = offset
 
     if (Math.abs(dx) > CLICK_SUPPRESS_DISTANCE) {

--- a/Homassy.Web/app/pages/profile/products.vue
+++ b/Homassy.Web/app/pages/profile/products.vue
@@ -110,7 +110,6 @@
           :search-query="searchQuery"
           @select="openOverview"
           @edit="openEditDrawer"
-          @deleted="onDeleted"
         />
       </AnimatedList>
     </template>
@@ -337,10 +336,6 @@ function onSaved(product: ProductInfo) {
   const idx = products.value.findIndex(p => p.publicId === product.publicId)
   if (idx >= 0) products.value[idx] = product
   else products.value.push(product)
-}
-
-function onDeleted(publicId: string) {
-  removeProduct(publicId)
 }
 
 function handleUpserted(dto: ProductInfo) {

--- a/Homassy.Web/app/utils/errorCodes.ts
+++ b/Homassy.Web/app/utils/errorCodes.ts
@@ -33,6 +33,7 @@ export const errorCodeMessages: Record<string, string> = {
   'PRODUCT-0001': 'Product not found.',
   'PRODUCT-0002': 'Access to this product is denied.',
   'PRODUCT-0003': 'Inventory item not found.',
+  'PRODUCT-0004': 'Products are shared by every family, so they cannot be deleted. Remove your own inventory items instead.',
 
   // Location Errors (LOCATION-0xxx)
   'LOCATION-0001': 'Location not found.',

--- a/Homassy.Web/i18n/locales/de.json
+++ b/Homassy.Web/i18n/locales/de.json
@@ -332,6 +332,7 @@
         "backToProducts": "Zurück zu Produkten",
         "inventoryHeader": "Inventarartikel",
         "noInventoryItems": "Keine Inventarartikel",
+        "sharedProductHint": "Produkte werden von allen Familien gemeinsam genutzt und können nicht gelöscht werden. Um ein Produkt aus dem eigenen Haushalt zu entfernen, lösche seine Inventarartikel (Artikel nach links wischen).",
         "expiredStocksCount": "Abgelaufen: {count}",
         "expiringSoonStocksCount": "Bald ablaufend: {count}",
         "normalStocksCount": "Normal: {count}",
@@ -428,7 +429,6 @@
           "success": "Bestand erfolgreich aufgeteilt"
         },
         "editProduct": "Produkt bearbeiten",
-        "deleteProduct": "Produkt löschen",
         "editProductModal": {
           "title": "Produkt bearbeiten",
           "description": "Produktdetails ändern",
@@ -441,19 +441,6 @@
           "cancel": "Abbrechen",
           "confirm": "Speichern",
           "success": "Produkt erfolgreich aktualisiert"
-        },
-        "deleteProductModal": {
-          "title": "Produkt löschen",
-          "description": "Möchten Sie dieses Produkt wirklich löschen? Dadurch werden auch alle Bestandselemente gelöscht!",
-          "warning": "Warnung: Diese Aktion kann nicht rückgängig gemacht werden!",
-          "productName": "Produktname",
-          "brand": "Marke",
-          "category": "Kategorie",
-          "barcode": "Barcode",
-          "inventoryCount": "Anzahl der Bestandselemente",
-          "cancel": "Abbrechen",
-          "confirm": "Löschen",
-          "success": "Produkt erfolgreich gelöscht"
         }
       }
     },

--- a/Homassy.Web/i18n/locales/en.json
+++ b/Homassy.Web/i18n/locales/en.json
@@ -334,6 +334,7 @@
         "backToProducts": "Back to Products",
         "inventoryHeader": "Inventory Items",
         "noInventoryItems": "No inventory items",
+        "sharedProductHint": "Products are shared by every family and cannot be deleted. To take one out of your home, remove its inventory items (swipe an item left).",
         "expiredStocksCount": "Expired: {count}",
         "expiringSoonStocksCount": "Expiring soon: {count}",
         "normalStocksCount": "Normal: {count}",
@@ -430,7 +431,6 @@
           "success": "Inventory split successfully"
         },
         "editProduct": "Edit Product",
-        "deleteProduct": "Delete Product",
         "editProductModal": {
           "title": "Edit Product",
           "description": "Modify the product details",
@@ -443,19 +443,6 @@
           "cancel": "Cancel",
           "confirm": "Save",
           "success": "Product updated successfully"
-        },
-        "deleteProductModal": {
-          "title": "Delete Product",
-          "description": "Are you sure you want to delete this product? This will delete all inventory items as well!",
-          "warning": "Warning: This action cannot be undone!",
-          "productName": "Product Name",
-          "brand": "Brand",
-          "category": "Category",
-          "barcode": "Barcode",
-          "inventoryCount": "Inventory Items Count",
-          "cancel": "Cancel",
-          "confirm": "Delete",
-          "success": "Product deleted successfully"
         }
       }
     },

--- a/Homassy.Web/i18n/locales/hu.json
+++ b/Homassy.Web/i18n/locales/hu.json
@@ -334,6 +334,7 @@
         "backToProducts": "Vissza a termékekhez",
         "inventoryHeader": "Készlet elemek",
         "noInventoryItems": "Nincsenek készlet elemek",
+        "sharedProductHint": "A termékeket minden család közösen használja, ezért nem törölhetők. Ha egy terméket ki szeretnél venni a saját otthonodból, töröld a hozzá tartozó készlet elemeket (húzd az elemet balra).",
         "expiredStocksCount": "Lejárt: {count}",
         "expiringSoonStocksCount": "Hamarosan lejáró: {count}",
         "normalStocksCount": "Normális: {count}",
@@ -431,7 +432,6 @@
           "success": "A készlet sikeresen felosztva"
         },
         "editProduct": "Termék szerkesztése",
-        "deleteProduct": "Termék törlése",
         "editProductModal": {
           "title": "Termék szerkesztése",
           "description": "Módosítsa a termék adatait",
@@ -444,19 +444,6 @@
           "cancel": "Mégse",
           "confirm": "Mentés",
           "success": "Termék sikeresen frissítve"
-        },
-        "deleteProductModal": {
-          "title": "Termék törlése",
-          "description": "Biztosan törölni kívánja ezt a terméket? Ez törli az összes készlet elemet is!",
-          "warning": "Figyelmeztetés: Ez a művelet nem visszavonható!",
-          "productName": "Termék neve",
-          "brand": "Márka",
-          "category": "Kategória",
-          "barcode": "Vonalkód",
-          "inventoryCount": "Készlet elemek száma",
-          "cancel": "Mégse",
-          "confirm": "Törlés",
-          "success": "Termék sikeresen törölve"
         }
       }
     },


### PR DESCRIPTION
Closes #62.

A `Product` row is global — only `ProductCustomization` is family-scoped — so deleting a product removed it, and its inventory items, for every family using it.

## Backend
- New `ErrorCodes.ProductDeletionNotAllowed` (`PRODUCT-0004`) with description.
- `DELETE /api/v1.0/product/{productPublicId}` always answers **403** with that code; no deletion is attempted, so the previous side effects (disabling automations, clearing `ProductId` on shopping list items) no longer run in the user flow.
- `ProductFunctions.DeleteProductAsync` stays for maintenance/administrative use and is documented as not reachable through the public API surface.
- `DeleteProduct_NonExistent_ReturnsNotFound` replaced by `DeleteProduct_Authenticated_ReturnsForbidden`, asserting 403 + the error code.

## Frontend
- `DataProductCard` loses its swipe-left delete, the confirm drawer, and the `deleted` emit; only swipe-right (edit) remains.
- `deleteProduct` removed from `useProductsApi`; the obsolete `deleteProduct` / `deleteProductModal` i18n keys removed from en/hu/de.
- The inventory list now explains that products are shared and that removal happens per family through the inventory items (new `sharedProductHint` key in all three locales), keeping the family-scoped flow discoverable where the delete used to be.
- `useSwipeActions` no longer drags toward a direction that has no handler, so the empty action layer is never revealed.
- `PRODUCT-0004` added to the frontend error code map.