### PR TITLE
feat(calendar): remind family members about synced events

### DIFF
--- a/Homassy.API/Constants/ErrorCodeDescriptions.cs
+++ b/Homassy.API/Constants/ErrorCodeDescriptions.cs
@@ -102,7 +102,8 @@ public static class ErrorCodeDescriptions
         [ErrorCodes.ExternalCalendarAccessDenied] = "Access denied to this external calendar.",
         [ErrorCodes.ExternalCalendarInvalidUrl] = "The provided URL is not a valid iCal feed.",
         [ErrorCodes.ExternalCalendarFetchFailed] = "Failed to fetch the iCal feed from the provided URL.",
-        [ErrorCodes.ExternalCalendarRequiresFamily] = "You must be a member of a family to manage external calendars."
+        [ErrorCodes.ExternalCalendarRequiresFamily] = "You must be a member of a family to manage external calendars.",
+        [ErrorCodes.ExternalCalendarInvalidReminder] = "The reminder settings are invalid."
     }.ToFrozenDictionary();
 
     public static IReadOnlyList<ErrorCodeInfo> GetAllErrorCodes()

--- a/Homassy.API/Context/HomassyDbContext.cs
+++ b/Homassy.API/Context/HomassyDbContext.cs
@@ -117,6 +117,33 @@ namespace Homassy.API.Context
                 entity.HasIndex(e => new { e.FamilyId, e.IsEnabled });
                 entity.Property(e => e.CachedEventsJson).HasColumnType("text");
             });
+
+            modelBuilder.Entity<ExternalCalendarReminderDispatch>(entity =>
+            {
+                entity.HasOne<FamilyExternalCalendar>()
+                    .WithMany()
+                    .HasForeignKey(d => d.ExternalCalendarId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                entity.HasOne<User>()
+                    .WithMany()
+                    .HasForeignKey(d => d.UserId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                // The occurrence key is an identifier, not an instant, so it must not be reinterpreted
+                // against a timezone the way a `timestamptz` column would be.
+                entity.Property(e => e.OccurrenceKey).HasColumnType("timestamp without time zone");
+
+                // Guarantees at-most-once delivery per (calendar, member, occurrence, lead time) even if
+                // two worker instances race. The explicit name keeps it under PostgreSQL's 63-char limit.
+                entity.HasIndex(e => new { e.ExternalCalendarId, e.UserId, e.EventUid, e.OccurrenceKey, e.LeadTimeMinutes })
+                    .HasDatabaseName("IX_ExtCalReminderDispatches_Occurrence")
+                    .IsUnique();
+
+                // Supports the worker's retention sweep.
+                entity.HasIndex(e => e.SentAt)
+                    .HasDatabaseName("IX_ExtCalReminderDispatches_SentAt");
+            });
             #endregion
 
             #region FamilyJoinRequest Relationships
@@ -280,6 +307,7 @@ namespace Homassy.API.Context
         public DbSet<Family> Families { get; set; }
         public DbSet<FamilyJoinRequest> FamilyJoinRequests { get; set; }
         public DbSet<FamilyExternalCalendar> FamilyExternalCalendars { get; set; }
+        public DbSet<ExternalCalendarReminderDispatch> ExternalCalendarReminderDispatches { get; set; }
         #endregion
 
         #region Product Related DbSets

--- a/Homassy.API/Entities/Family/ExternalCalendarReminderDispatch.cs
+++ b/Homassy.API/Entities/Family/ExternalCalendarReminderDispatch.cs
@@ -1,0 +1,41 @@
+using Homassy.API.Entities.Common;
+using System.ComponentModel.DataAnnotations;
+
+namespace Homassy.API.Entities.Family
+{
+    /// <summary>
+    /// A record that one reminder has already been pushed, so a re-sync or a worker restart cannot send
+    /// it twice. The occurrence is identified by <see cref="EventUid"/> + <see cref="OccurrenceKey"/>,
+    /// which also gives moved events their re-arming for free: a moved occurrence produces a different
+    /// key, so it has no marker yet and is treated as a fresh reminder. Deleted events simply stop
+    /// appearing in the synced cache and never trigger.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately holds no navigation properties. Nothing reads the parent rows through this table, and a
+    /// required navigation to a soft-delete-filtered principal makes EF log a query-filter interaction
+    /// warning on every model build. The foreign keys (and their cascades) are configured in
+    /// <c>HomassyDbContext</c> without them.
+    /// </remarks>
+    public class ExternalCalendarReminderDispatch : BaseEntity
+    {
+        public int ExternalCalendarId { get; set; }
+
+        public int UserId { get; set; }
+
+        [Required]
+        [StringLength(512)]
+        public required string EventUid { get; set; }
+
+        /// <summary>
+        /// Identifies the occurrence within the event series. For a timed event this is the occurrence's
+        /// UTC start; for an all-day event it is the event date at 00:00. Stored as
+        /// <c>timestamp without time zone</c> because it is a key, not an instant.
+        /// </summary>
+        public DateTime OccurrenceKey { get; set; }
+
+        /// <summary>Which of the calendar's configured lead times this dispatch covers.</summary>
+        public int LeadTimeMinutes { get; set; }
+
+        public DateTime SentAt { get; set; }
+    }
+}

--- a/Homassy.API/Entities/Family/FamilyExternalCalendar.cs
+++ b/Homassy.API/Entities/Family/FamilyExternalCalendar.cs
@@ -27,5 +27,19 @@ namespace Homassy.API.Entities.Family
         public string? LastSyncError { get; set; }
 
         public string? CachedEventsJson { get; set; }
+
+        /// <summary>
+        /// Reminder lead times in minutes before an event starts, as a JSON int array
+        /// (e.g. <c>[1440,15]</c> = one day and 15 minutes before). <c>0</c> means "at start".
+        /// Null or an empty array disables reminders for this calendar.
+        /// </summary>
+        [StringLength(256)]
+        public string? ReminderLeadTimesJson { get; set; }
+
+        /// <summary>
+        /// Time of day an all-day event's reminder is anchored to, instead of midnight. Interpreted in
+        /// each recipient's own timezone, so members in different zones are notified at their local 08:00.
+        /// </summary>
+        public TimeOnly AllDayNotifyTime { get; set; } = new(8, 0);
     }
 }

--- a/Homassy.API/Enums/ErrorCode.cs
+++ b/Homassy.API/Enums/ErrorCode.cs
@@ -113,5 +113,6 @@ public static class ErrorCodes
     public const string ExternalCalendarInvalidUrl = "EXTCAL-0003";
     public const string ExternalCalendarFetchFailed = "EXTCAL-0004";
     public const string ExternalCalendarRequiresFamily = "EXTCAL-0005";
+    public const string ExternalCalendarInvalidReminder = "EXTCAL-0006";
     #endregion
 }

--- a/Homassy.API/Exceptions/ExternalCalendarException.cs
+++ b/Homassy.API/Exceptions/ExternalCalendarException.cs
@@ -30,6 +30,13 @@ namespace Homassy.API.Exceptions
         public ExternalCalendarFetchFailedException(string message = "Failed to fetch iCal feed") : base(message) { }
     }
 
+    public class ExternalCalendarInvalidReminderException : Exception
+    {
+        public string ErrorCode { get; } = ErrorCodes.ExternalCalendarInvalidReminder;
+
+        public ExternalCalendarInvalidReminderException(string message = "Invalid reminder settings") : base(message) { }
+    }
+
     public class ExternalCalendarRequiresFamilyException : Exception
     {
         public string ErrorCode { get; } = ErrorCodes.ExternalCalendarRequiresFamily;

--- a/Homassy.API/Functions/ExternalCalendarFunctions.cs
+++ b/Homassy.API/Functions/ExternalCalendarFunctions.cs
@@ -6,10 +6,13 @@ using Homassy.API.Models.Calendar;
 using Homassy.API.Models.ExternalCalendar;
 using Ical.Net;
 using Ical.Net.CalendarComponents;
+using Ical.Net.DataTypes;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
 using System.Text;
 using System.Text.Json;
+// Aliased rather than imported: `using System.Globalization` would make `Calendar` ambiguous with Ical.Net's.
+using CultureInfo = System.Globalization.CultureInfo;
 
 namespace Homassy.API.Functions
 {
@@ -19,6 +22,9 @@ namespace Homassy.API.Functions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase
         };
+
+        private const int MaxReminderLeadTimes = 8;
+        private const int MaxReminderLeadTimeMinutes = 30 * 24 * 60;
 
         public async Task<List<ExternalCalendarResponse>> GetExternalCalendarsAsync(CancellationToken ct = default)
         {
@@ -51,8 +57,12 @@ namespace Homassy.API.Functions
                 FamilyId = familyId,
                 Name = request.Name,
                 ICalUrl = normalizedUrl,
-                Color = request.Color
+                Color = request.Color,
+                ReminderLeadTimesJson = NormalizeReminderLeadTimes(request.ReminderLeadTimes)
             };
+
+            if (request.AllDayNotifyTime != null)
+                calendar.AllDayNotifyTime = ParseAllDayNotifyTime(request.AllDayNotifyTime);
 
             context.FamilyExternalCalendars.Add(calendar);
             await context.SaveChangesAsync(ct);
@@ -82,6 +92,13 @@ namespace Homassy.API.Functions
             if (request.Name != null) calendar.Name = request.Name;
             if (request.Color != null) calendar.Color = request.Color;
             if (request.IsEnabled.HasValue) calendar.IsEnabled = request.IsEnabled.Value;
+
+            // A null list means "leave reminders as they are"; an empty one turns them off.
+            if (request.ReminderLeadTimes != null)
+                calendar.ReminderLeadTimesJson = NormalizeReminderLeadTimes(request.ReminderLeadTimes);
+
+            if (request.AllDayNotifyTime != null)
+                calendar.AllDayNotifyTime = ParseAllDayNotifyTime(request.AllDayNotifyTime);
 
             if (request.ICalUrl != null)
             {
@@ -360,7 +377,7 @@ namespace Homassy.API.Functions
                 foreach (var occ in cal.GetOccurrences(windowStart, windowEnd))
                 {
                     if (occ.Source is not CalendarEvent ev) continue;
-                    result.Add(MapEvent(ev, occ.Period.StartTime?.AsSystemLocal, occ.Period.EndTime?.AsSystemLocal));
+                    result.Add(MapEvent(ev, occ.Period.StartTime, occ.Period.EndTime));
                 }
             }
             catch (Exception ex)
@@ -368,7 +385,7 @@ namespace Homassy.API.Functions
                 Log.Warning(ex,
                     "External calendar {CalendarId}: occurrence expansion failed, storing master events only",
                     calendarId);
-                return cal.Events.Select(ev => MapEvent(ev, ev.DtStart?.AsSystemLocal, ev.DtEnd?.AsSystemLocal)).ToList();
+                return cal.Events.Select(ev => MapEvent(ev, ev.DtStart, ev.DtEnd)).ToList();
             }
 
             // Safety net: a non-recurring event that does not overlap the window is dropped by
@@ -384,20 +401,22 @@ namespace Homassy.API.Functions
                 var overlapsWindow = start.Value <= windowEnd && end >= windowStart;
                 if (overlapsWindow) continue;
 
-                result.Add(MapEvent(ev, start, ev.DtEnd?.AsSystemLocal));
+                result.Add(MapEvent(ev, ev.DtStart, ev.DtEnd));
             }
 
             return result;
         }
 
-        private static CachedICalEvent MapEvent(CalendarEvent ev, DateTime? start, DateTime? end) => new()
+        private static CachedICalEvent MapEvent(CalendarEvent ev, IDateTime? start, IDateTime? end) => new()
         {
             Uid = ev.Uid ?? Guid.NewGuid().ToString(),
             Title = ev.Summary ?? string.Empty,
-            Start = start ?? DateTime.UtcNow,
-            End = end,
+            Start = start?.AsSystemLocal ?? DateTime.UtcNow,
+            End = end?.AsSystemLocal,
             Description = ev.Description,
-            IsAllDay = ev.IsAllDay
+            IsAllDay = ev.IsAllDay,
+            // Server-local Start cannot be scheduled against; the reminder worker needs the absolute instant.
+            StartUtc = start?.AsUtc ?? DateTime.UtcNow
         };
 
         /// <summary>
@@ -431,6 +450,61 @@ namespace Homassy.API.Functions
             return blocks;
         }
 
+        /// <summary>
+        /// Validates and canonicalizes the configured lead times into the stored JSON array (deduplicated,
+        /// longest lead first). Returns null when reminders are off, so "no reminders" has a single
+        /// representation in the database.
+        /// </summary>
+        private static string? NormalizeReminderLeadTimes(List<int>? leadTimes)
+        {
+            if (leadTimes == null)
+                return null;
+
+            var normalized = leadTimes.Distinct().OrderByDescending(m => m).ToList();
+
+            if (normalized.Count == 0)
+                return null;
+
+            if (normalized.Count > MaxReminderLeadTimes)
+                throw new ExternalCalendarInvalidReminderException(
+                    $"At most {MaxReminderLeadTimes} reminder lead times can be configured per calendar.");
+
+            if (normalized.Any(m => m < 0 || m > MaxReminderLeadTimeMinutes))
+                throw new ExternalCalendarInvalidReminderException(
+                    "Reminder lead times must be between 0 minutes (at start) and 30 days.");
+
+            return JsonSerializer.Serialize(normalized, JsonOptions);
+        }
+
+        private static TimeOnly ParseAllDayNotifyTime(string value)
+        {
+            if (!TimeOnly.TryParse(value, CultureInfo.InvariantCulture, out var parsed))
+                throw new ExternalCalendarInvalidReminderException(
+                    "The all-day notification time must be given as HH:mm.");
+
+            return parsed;
+        }
+
+        /// <summary>
+        /// Reads the stored lead times back. Also used by the reminder worker in Homassy.Notifications,
+        /// so the storage format has exactly one reader. Unparseable JSON yields no reminders rather than
+        /// taking the worker down.
+        /// </summary>
+        public static List<int> ParseReminderLeadTimes(string? json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+                return [];
+
+            try
+            {
+                return JsonSerializer.Deserialize<List<int>>(json, JsonOptions) ?? [];
+            }
+            catch (JsonException)
+            {
+                return [];
+            }
+        }
+
         private static string NormalizeICalUrl(string url)
         {
             if (url.StartsWith("webcal://", StringComparison.OrdinalIgnoreCase))
@@ -462,7 +536,9 @@ namespace Homassy.API.Functions
                 IsEnabled = calendar.IsEnabled,
                 LastSyncedAt = calendar.LastSyncedAt,
                 LastSyncError = calendar.LastSyncError,
-                EventCount = eventCount
+                EventCount = eventCount,
+                ReminderLeadTimes = ParseReminderLeadTimes(calendar.ReminderLeadTimesJson),
+                AllDayNotifyTime = calendar.AllDayNotifyTime.ToString(@"HH\:mm", CultureInfo.InvariantCulture)
             };
         }
     }

--- a/Homassy.API/Middleware/GlobalExceptionMiddleware.cs
+++ b/Homassy.API/Middleware/GlobalExceptionMiddleware.cs
@@ -95,6 +95,7 @@ namespace Homassy.API.Middleware
                 ExternalCalendarInvalidUrlException ex => (StatusCodes.Status400BadRequest, ex.ErrorCode),
                 ExternalCalendarFetchFailedException ex => (StatusCodes.Status400BadRequest, ex.ErrorCode),
                 ExternalCalendarRequiresFamilyException ex => (StatusCodes.Status400BadRequest, ex.ErrorCode),
+                ExternalCalendarInvalidReminderException ex => (StatusCodes.Status400BadRequest, ex.ErrorCode),
 
                 // Timeout exceptions
                 RequestTimeoutException ex => (StatusCodes.Status504GatewayTimeout, ex.ErrorCode),

--- a/Homassy.API/Migrations/20260729162526_AddExternalCalendarReminders.Designer.cs
+++ b/Homassy.API/Migrations/20260729162526_AddExternalCalendarReminders.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Homassy.API.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Homassy.API.Migrations
 {
     [DbContext(typeof(HomassyDbContext))]
-    partial class HomassyDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260729162526_AddExternalCalendarReminders")]
+    partial class AddExternalCalendarReminders
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Homassy.API/Migrations/20260729162526_AddExternalCalendarReminders.cs
+++ b/Homassy.API/Migrations/20260729162526_AddExternalCalendarReminders.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Homassy.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExternalCalendarReminders : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<TimeOnly>(
+                name: "AllDayNotifyTime",
+                table: "FamilyExternalCalendars",
+                type: "time without time zone",
+                nullable: false,
+                // Existing rows must match the entity default (08:00), not midnight — midnight is the very
+                // thing the all-day notify time exists to avoid.
+                defaultValue: new TimeOnly(8, 0, 0));
+
+            migrationBuilder.AddColumn<string>(
+                name: "ReminderLeadTimesJson",
+                table: "FamilyExternalCalendars",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "ExternalCalendarReminderDispatches",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ExternalCalendarId = table.Column<int>(type: "integer", nullable: false),
+                    UserId = table.Column<int>(type: "integer", nullable: false),
+                    EventUid = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    OccurrenceKey = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                    LeadTimeMinutes = table.Column<int>(type: "integer", nullable: false),
+                    SentAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    PublicId = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExternalCalendarReminderDispatches", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ExternalCalendarReminderDispatches_FamilyExternalCalendars_~",
+                        column: x => x.ExternalCalendarId,
+                        principalTable: "FamilyExternalCalendars",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ExternalCalendarReminderDispatches_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExtCalReminderDispatches_Occurrence",
+                table: "ExternalCalendarReminderDispatches",
+                columns: new[] { "ExternalCalendarId", "UserId", "EventUid", "OccurrenceKey", "LeadTimeMinutes" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExtCalReminderDispatches_SentAt",
+                table: "ExternalCalendarReminderDispatches",
+                column: "SentAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExternalCalendarReminderDispatches_UserId",
+                table: "ExternalCalendarReminderDispatches",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ExternalCalendarReminderDispatches");
+
+            migrationBuilder.DropColumn(
+                name: "AllDayNotifyTime",
+                table: "FamilyExternalCalendars");
+
+            migrationBuilder.DropColumn(
+                name: "ReminderLeadTimesJson",
+                table: "FamilyExternalCalendars");
+        }
+    }
+}

--- a/Homassy.API/Models/ExternalCalendar/CachedICalEvent.cs
+++ b/Homassy.API/Models/ExternalCalendar/CachedICalEvent.cs
@@ -8,5 +8,13 @@ namespace Homassy.API.Models.ExternalCalendar
         public DateTime? End { get; set; }
         public string? Description { get; set; }
         public bool IsAllDay { get; set; }
+
+        /// <summary>
+        /// Absolute start of the occurrence. <see cref="Start"/> is server-local and carries no offset,
+        /// so it cannot be used to schedule anything; reminder trigger times are computed from this.
+        /// Entries cached before this field existed deserialize to <c>default</c> and are skipped by the
+        /// reminder worker until the next sync refills them.
+        /// </summary>
+        public DateTime StartUtc { get; set; }
     }
 }

--- a/Homassy.API/Models/ExternalCalendar/CreateExternalCalendarRequest.cs
+++ b/Homassy.API/Models/ExternalCalendar/CreateExternalCalendarRequest.cs
@@ -16,5 +16,12 @@ namespace Homassy.API.Models.ExternalCalendar
 
         [StringLength(7)]
         public string Color { get; set; } = "#3B82F6";
+
+        /// <summary>Reminder lead times in minutes before the event starts; <c>0</c> = at start.</summary>
+        public List<int>? ReminderLeadTimes { get; set; }
+
+        /// <summary>Time of day all-day reminders are anchored to, as <c>HH:mm</c>. Defaults to 08:00.</summary>
+        [StringLength(8)]
+        public string? AllDayNotifyTime { get; set; }
     }
 }

--- a/Homassy.API/Models/ExternalCalendar/ExternalCalendarResponse.cs
+++ b/Homassy.API/Models/ExternalCalendar/ExternalCalendarResponse.cs
@@ -10,5 +10,11 @@ namespace Homassy.API.Models.ExternalCalendar
         public DateTime? LastSyncedAt { get; set; }
         public string? LastSyncError { get; set; }
         public int EventCount { get; set; }
+
+        /// <summary>Reminder lead times in minutes before the event starts; empty = reminders off.</summary>
+        public List<int> ReminderLeadTimes { get; set; } = [];
+
+        /// <summary>Time of day all-day reminders are anchored to, as <c>HH:mm</c>.</summary>
+        public string AllDayNotifyTime { get; set; } = "08:00";
     }
 }

--- a/Homassy.API/Models/ExternalCalendar/UpdateExternalCalendarRequest.cs
+++ b/Homassy.API/Models/ExternalCalendar/UpdateExternalCalendarRequest.cs
@@ -16,5 +16,15 @@ namespace Homassy.API.Models.ExternalCalendar
         public string? Color { get; set; }
 
         public bool? IsEnabled { get; set; }
+
+        /// <summary>
+        /// Reminder lead times in minutes before the event starts. Null leaves them unchanged;
+        /// an empty array turns reminders off for this calendar.
+        /// </summary>
+        public List<int>? ReminderLeadTimes { get; set; }
+
+        /// <summary>Time of day all-day reminders are anchored to, as <c>HH:mm</c>.</summary>
+        [StringLength(8)]
+        public string? AllDayNotifyTime { get; set; }
     }
 }

--- a/Homassy.Notifications/CLAUDE.md
+++ b/Homassy.Notifications/CLAUDE.md
@@ -79,6 +79,7 @@ Homassy.Notifications/
     ├── InventoryActivityMonitorService.cs     # 5 min → inventory (készlet) push
     ├── FamilyJoinRequestMonitorService.cs     # 1 min → family join request push
     ├── ItemAutomationWorkerService.cs         # 5 min → item automation execution
+    ├── ExternalCalendarReminderService.cs     # 1 min → synced iCal event reminders
     └── EmailWeeklySummaryService.cs           # Hourly, Mon 07:00 → weekly email
 ```
 
@@ -164,6 +165,23 @@ builder.Services.AddDbContext<HomassyDbContext>(options =>
 - After an `AutoConsume` commit it relays the inventory change to `Homassy.API` via
   `InventoryBroadcastServiceClient` (→ `POST /api/v1/internal/inventory/broadcast`) so connected
   Készletek grids update live; this process hosts no SignalR hub, so it cannot broadcast directly
+
+### ExternalCalendarReminderService
+- Runs every minute, so an "at start" reminder is not up to an hour late
+- Reads the events `Homassy.API`'s `ExternalCalendarSyncService` caches hourly in
+  `FamilyExternalCalendar.CachedEventsJson`; reminder lead times live on the same row
+  (`ReminderLeadTimesJson`, a JSON minute array — `0` = at start) together with `AllDayNotifyTime`
+- Trigger time for a timed event is `StartUtc - leadTime` (identical for everyone); an all-day event has
+  no time of day, so it is anchored to `AllDayNotifyTime` **in each recipient's own timezone**
+  (`UserProfile.DefaultTimeZone`) and then shifted back by the lead time
+- Recipients are the family members resolved by `FamilyPushNotifier` (push enabled + a live subscription)
+- Duplicate suppression is claim-then-push: an `ExternalCalendarReminderDispatch` row keyed by
+  (calendar, user, event UID, occurrence, lead time) is committed **before** the push, and the unique
+  index makes a lost race skip a send rather than repeat one. A moved occurrence gets a new key and
+  re-arms itself; a deleted event stops appearing in the cache and never fires. Markers older than
+  30 days are pruned every 6 hours
+- Reminders whose trigger already passed are still delivered within a 15-minute catch-up window, so a
+  deploy or restart does not swallow them; anything older is dropped as stale
 
 ### EmailWeeklySummaryService
 - Runs every hour

--- a/Homassy.Notifications/Program.cs
+++ b/Homassy.Notifications/Program.cs
@@ -44,6 +44,7 @@ try
     builder.Services.AddHostedService<FamilyJoinRequestMonitorService>();
     builder.Services.AddHostedService<EmailWeeklySummaryService>();
     builder.Services.AddHostedService<ItemAutomationWorkerService>();
+    builder.Services.AddHostedService<ExternalCalendarReminderService>();
 
     // Health checks
     builder.Services.AddHealthChecks()

--- a/Homassy.Notifications/Services/FamilyPushNotifier.cs
+++ b/Homassy.Notifications/Services/FamilyPushNotifier.cs
@@ -40,7 +40,8 @@ public sealed class FamilyPushNotifier
             .Where(u => context.UserPushSubscriptions.Any(s => s.UserId == u.Id && !s.IsDeleted))
             .Select(u => new RecipientInfo(
                 u.Id,
-                u.Profile != null ? u.Profile.DefaultLanguage : Language.Hungarian))
+                u.Profile != null ? u.Profile.DefaultLanguage : Language.Hungarian,
+                u.Profile != null ? u.Profile.DefaultTimeZone : UserTimeZone.CentralEuropeStandardTime))
             .ToListAsync(cancellationToken);
     }
 
@@ -63,11 +64,12 @@ public sealed class FamilyPushNotifier
             .Select(u => new
             {
                 u.Id,
-                Language = u.Profile != null ? u.Profile.DefaultLanguage : Language.Hungarian
+                Language = u.Profile != null ? u.Profile.DefaultLanguage : Language.Hungarian,
+                TimeZone = u.Profile != null ? u.Profile.DefaultTimeZone : UserTimeZone.CentralEuropeStandardTime
             })
             .FirstOrDefaultAsync(cancellationToken);
 
-        return user == null ? null : new RecipientInfo(user.Id, user.Language);
+        return user == null ? null : new RecipientInfo(user.Id, user.Language, user.TimeZone);
     }
 
     /// <summary>
@@ -129,4 +131,11 @@ public sealed class FamilyPushNotifier
     };
 }
 
-public readonly record struct RecipientInfo(int Id, Language Language);
+/// <summary>
+/// A member eligible for a push notification. <paramref name="TimeZone"/> defaults to the app-wide
+/// fallback so notifiers that do not schedule anything can keep constructing this with two arguments.
+/// </summary>
+public readonly record struct RecipientInfo(
+    int Id,
+    Language Language,
+    UserTimeZone TimeZone = UserTimeZone.CentralEuropeStandardTime);

--- a/Homassy.Notifications/Services/PushNotificationContentService.cs
+++ b/Homassy.Notifications/Services/PushNotificationContentService.cs
@@ -1,4 +1,4 @@
-﻿using Homassy.API.Enums;
+using Homassy.API.Enums;
 
 namespace Homassy.Notifications.Services;
 
@@ -424,6 +424,83 @@ public static class PushNotificationContentService
                 "Join request declined",
                 $"Your request to join the \"{familyName}\" family was declined."
             )
+        };
+    }
+
+    /// <summary>
+    /// Reminder for an event coming from a synced external (iCal) calendar. The lead time is phrased
+    /// relatively ("in 15 minutes"), which stays correct for every recipient because the trigger instant
+    /// is computed per recipient before this text is built.
+    /// </summary>
+    public static (string Title, string Body) GetCalendarEventReminderContent(
+        Language language, string eventTitle, int leadTimeMinutes, bool isAllDay)
+    {
+        var title = language switch
+        {
+            Language.Hungarian => "Naptár emlékeztető",
+            Language.German => "Kalendererinnerung",
+            _ => "Calendar reminder"
+        };
+
+        if (isAllDay)
+        {
+            var body = (language, leadTimeMinutes) switch
+            {
+                (Language.Hungarian, 0) => $"\"{eventTitle}\" ma van.",
+                (Language.Hungarian, 1440) => $"\"{eventTitle}\" holnap lesz.",
+                (Language.Hungarian, _) => $"\"{eventTitle}\" {DescribeLeadTime(language, leadTimeMinutes)} múlva lesz.",
+                (Language.German, 0) => $"\"{eventTitle}\" ist heute.",
+                (Language.German, 1440) => $"\"{eventTitle}\" ist morgen.",
+                (Language.German, _) => $"\"{eventTitle}\" ist in {DescribeLeadTime(language, leadTimeMinutes)}.",
+                (_, 0) => $"\"{eventTitle}\" is today.",
+                (_, 1440) => $"\"{eventTitle}\" is tomorrow.",
+                _ => $"\"{eventTitle}\" is in {DescribeLeadTime(language, leadTimeMinutes)}."
+            };
+
+            return (title, body);
+        }
+
+        return (title, (language, leadTimeMinutes) switch
+        {
+            (Language.Hungarian, 0) => $"\"{eventTitle}\" most kezdődik.",
+            (Language.Hungarian, _) => $"\"{eventTitle}\" {DescribeLeadTime(language, leadTimeMinutes)} múlva kezdődik.",
+            (Language.German, 0) => $"\"{eventTitle}\" beginnt jetzt.",
+            (Language.German, _) => $"\"{eventTitle}\" beginnt in {DescribeLeadTime(language, leadTimeMinutes)}.",
+            (_, 0) => $"\"{eventTitle}\" is starting now.",
+            _ => $"\"{eventTitle}\" starts in {DescribeLeadTime(language, leadTimeMinutes)}."
+        });
+    }
+
+    /// <summary>Renders a lead time in the largest whole unit it divides into (minutes → hours → days).</summary>
+    private static string DescribeLeadTime(Language language, int minutes)
+    {
+        if (minutes % 1440 == 0)
+        {
+            var days = minutes / 1440;
+            return language switch
+            {
+                Language.Hungarian => $"{days} nap",
+                Language.German => days == 1 ? "1 Tag" : $"{days} Tagen",
+                _ => days == 1 ? "1 day" : $"{days} days"
+            };
+        }
+
+        if (minutes % 60 == 0)
+        {
+            var hours = minutes / 60;
+            return language switch
+            {
+                Language.Hungarian => $"{hours} óra",
+                Language.German => hours == 1 ? "1 Stunde" : $"{hours} Stunden",
+                _ => hours == 1 ? "1 hour" : $"{hours} hours"
+            };
+        }
+
+        return language switch
+        {
+            Language.Hungarian => $"{minutes} perc",
+            Language.German => minutes == 1 ? "1 Minute" : $"{minutes} Minuten",
+            _ => minutes == 1 ? "1 minute" : $"{minutes} minutes"
         };
     }
 }

--- a/Homassy.Notifications/Workers/ExternalCalendarReminderService.cs
+++ b/Homassy.Notifications/Workers/ExternalCalendarReminderService.cs
@@ -1,0 +1,392 @@
+using Homassy.API.Context;
+using Homassy.API.Entities.Family;
+using Homassy.API.Enums;
+using Homassy.API.Extensions;
+using Homassy.API.Functions;
+using Homassy.API.Models.ExternalCalendar;
+using Homassy.Notifications.Services;
+using Microsoft.EntityFrameworkCore;
+using Serilog;
+using System.Text.Json;
+
+namespace Homassy.Notifications.Workers;
+
+/// <summary>
+/// Turns events from the synced external (iCal) calendars into push reminders. Each calendar carries its
+/// own lead times (see <see cref="FamilyExternalCalendar.ReminderLeadTimesJson"/>); every family member
+/// with push notifications enabled is reminded once per occurrence and lead time.
+/// <para>
+/// The cache is refreshed hourly by <c>ExternalCalendarSyncService</c> in Homassy.API, but reminders are
+/// evaluated every minute so an "at start" reminder is not up to an hour late. That also means a moved or
+/// deleted event is only reflected after the next sync.
+/// </para>
+/// <para>
+/// Duplicate suppression is a claim-then-push: the <see cref="ExternalCalendarReminderDispatch"/> row is
+/// written and committed *before* the push goes out, so a lost race on the unique index (or a re-sync, or
+/// a restart inside the catch-up window) can only ever skip a send, never repeat one.
+/// </para>
+/// </summary>
+public sealed class ExternalCalendarReminderService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly FamilyPushNotifier _notifier;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly TimeSpan _interval = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// A trigger time that has already passed is still delivered inside this window, so a deploy or a
+    /// short outage does not silently swallow a reminder. Anything older is dropped as stale — nobody
+    /// wants "starts in 15 minutes" hours after the fact.
+    /// </summary>
+    private static readonly TimeSpan CatchUpWindow = TimeSpan.FromMinutes(15);
+
+    private static readonly TimeSpan MarkerRetention = TimeSpan.FromDays(30);
+    private static readonly TimeSpan PruneInterval = TimeSpan.FromHours(6);
+    private DateTime _nextPruneUtc = DateTime.MinValue;
+
+    /// <summary>Matches <see cref="ExternalCalendarReminderDispatch.EventUid"/>'s column length.</summary>
+    private const int MaxEventUidLength = 512;
+
+    public ExternalCalendarReminderService(IServiceScopeFactory scopeFactory, FamilyPushNotifier notifier)
+    {
+        _scopeFactory = scopeFactory;
+        _notifier = notifier;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        Log.Information("External calendar reminder service started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(_interval, stoppingToken);
+                await ProcessAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error in external calendar reminder service");
+                try { await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken); }
+                catch (OperationCanceledException) { break; }
+            }
+        }
+
+        Log.Information("External calendar reminder service stopped");
+    }
+
+    private async Task ProcessAsync(CancellationToken cancellationToken)
+    {
+        var nowUtc = DateTime.UtcNow;
+
+        using var scope = _scopeFactory.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<HomassyDbContext>();
+
+        var calendars = await context.FamilyExternalCalendars
+            .AsNoTracking()
+            .Where(c => c.IsEnabled && c.ReminderLeadTimesJson != null && c.CachedEventsJson != null)
+            .Select(c => new CalendarState(
+                c.Id,
+                c.PublicId,
+                c.FamilyId,
+                c.ReminderLeadTimesJson!,
+                c.AllDayNotifyTime,
+                c.CachedEventsJson!))
+            .ToListAsync(cancellationToken);
+
+        foreach (var calendar in calendars)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return;
+
+            try
+            {
+                await ProcessCalendarAsync(context, calendar, nowUtc, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error processing reminders for external calendar {CalendarId}", calendar.PublicId);
+            }
+        }
+
+        await PruneDispatchesAsync(context, nowUtc, cancellationToken);
+    }
+
+    private async Task ProcessCalendarAsync(
+        HomassyDbContext context,
+        CalendarState calendar,
+        DateTime nowUtc,
+        CancellationToken cancellationToken)
+    {
+        var leadTimes = ExternalCalendarFunctions.ParseReminderLeadTimes(calendar.ReminderLeadTimesJson);
+        if (leadTimes.Count == 0)
+            return;
+
+        var events = DeserializeEvents(calendar);
+        if (events.Count == 0)
+            return;
+
+        var recipients = await _notifier.GetRecipientsAsync(context, calendar.FamilyId, [], cancellationToken);
+        if (recipients.Count == 0)
+            return;
+
+        var due = CollectDueReminders(calendar, events, leadTimes, recipients, nowUtc);
+        if (due.Count == 0)
+            return;
+
+        var alreadySent = await LoadDispatchedKeysAsync(context, calendar.Id, due, cancellationToken);
+
+        foreach (var reminder in due)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return;
+
+            var uid = TruncateUid(reminder.Event.Uid);
+            var key = (reminder.Recipient.Id, uid, reminder.OccurrenceKey, reminder.LeadTimeMinutes);
+
+            // Also collapses duplicates inside this batch: the same occurrence can appear more than once
+            // in a feed that repeats a UID across overlapping RDATE/RRULE definitions.
+            if (!alreadySent.Add(key))
+                continue;
+
+            var marker = new ExternalCalendarReminderDispatch
+            {
+                ExternalCalendarId = calendar.Id,
+                UserId = reminder.Recipient.Id,
+                EventUid = uid,
+                OccurrenceKey = reminder.OccurrenceKey,
+                LeadTimeMinutes = reminder.LeadTimeMinutes,
+                SentAt = DateTime.UtcNow
+            };
+
+            context.ExternalCalendarReminderDispatches.Add(marker);
+
+            try
+            {
+                await context.SaveChangesAsync(cancellationToken);
+            }
+            catch (DbUpdateException ex)
+            {
+                // Another instance claimed this reminder first. Detach so the shared context stays usable
+                // for the remaining calendars.
+                context.Entry(marker).State = EntityState.Detached;
+                Log.Debug(ex,
+                    "Calendar reminder for event {EventUid} / user {UserId} was already claimed elsewhere",
+                    uid, reminder.Recipient.Id);
+                continue;
+            }
+
+            await _notifier.DispatchAsync(context, [reminder.Recipient],
+                language =>
+                [
+                    PushNotificationContentService.GetCalendarEventReminderContent(
+                        language, reminder.Event.Title, reminder.LeadTimeMinutes, reminder.Event.IsAllDay)
+                ],
+                "/calendar", cancellationToken);
+
+            Log.Information(
+                "Calendar reminder sent to user {UserId} for event \"{EventTitle}\" ({LeadTime} min lead) on calendar {CalendarId}",
+                reminder.Recipient.Id, reminder.Event.Title, reminder.LeadTimeMinutes, calendar.PublicId);
+        }
+    }
+
+    /// <summary>
+    /// Expands the cached events into the (recipient, occurrence, lead time) triples whose trigger instant
+    /// falls inside the current window. Trigger times are per recipient because an all-day event is
+    /// anchored to the calendar's notify time in the recipient's own timezone.
+    /// </summary>
+    private static List<DueReminder> CollectDueReminders(
+        CalendarState calendar,
+        List<CachedICalEvent> events,
+        List<int> leadTimes,
+        List<RecipientInfo> recipients,
+        DateTime nowUtc)
+    {
+        var candidates = FilterToHorizon(events, leadTimes, nowUtc);
+        if (candidates.Count == 0)
+            return [];
+
+        var due = new List<DueReminder>();
+
+        foreach (var recipient in recipients)
+        {
+            var timeZone = ResolveTimeZone(recipient.TimeZone);
+
+            foreach (var ev in candidates)
+            {
+                foreach (var leadTime in leadTimes)
+                {
+                    var triggerUtc = ComputeTriggerUtc(ev, leadTime, calendar.AllDayNotifyTime, timeZone);
+                    if (triggerUtc == null)
+                        continue;
+
+                    if (triggerUtc > nowUtc || triggerUtc <= nowUtc - CatchUpWindow)
+                        continue;
+
+                    due.Add(new DueReminder(recipient, ev, leadTime, OccurrenceKeyOf(ev)));
+                }
+            }
+        }
+
+        return due;
+    }
+
+    /// <summary>
+    /// Narrows the (up to 14 months of) expanded occurrences down to the ones that could plausibly be due,
+    /// so the per-recipient trigger maths runs over a handful of events rather than the whole feed. The
+    /// two-day slack absorbs every timezone offset without needing to know the recipient's zone yet.
+    /// </summary>
+    private static List<CachedICalEvent> FilterToHorizon(List<CachedICalEvent> events, List<int> leadTimes, DateTime nowUtc)
+    {
+        var slack = TimeSpan.FromDays(2);
+        var from = nowUtc - CatchUpWindow - slack;
+        var to = nowUtc + TimeSpan.FromMinutes(leadTimes.Max()) + slack;
+
+        return events
+            .Where(ev => !string.IsNullOrWhiteSpace(ev.Uid))
+            .Where(ev =>
+            {
+                // Events cached before StartUtc existed land on DateTime.MinValue here and drop out; the
+                // next hourly sync backfills them.
+                var approximateStart = ev.IsAllDay ? ev.Start.Date : ev.StartUtc;
+                return approximateStart >= from && approximateStart <= to;
+            })
+            .ToList();
+    }
+
+    /// <summary>
+    /// The instant a reminder should fire, or null if the occurrence cannot be scheduled.
+    /// A timed event's lead time is absolute, so it is identical for every recipient; an all-day event has
+    /// no meaningful time of day, so it is anchored to the calendar's notify time in the recipient's zone
+    /// and then shifted back by the lead time (1 day before 08:00 → the previous day at 08:00).
+    /// </summary>
+    private static DateTime? ComputeTriggerUtc(
+        CachedICalEvent ev,
+        int leadTimeMinutes,
+        TimeOnly allDayNotifyTime,
+        TimeZoneInfo timeZone)
+    {
+        if (ev.IsAllDay)
+        {
+            var local = ev.Start.Date.Add(allDayNotifyTime.ToTimeSpan()).AddMinutes(-leadTimeMinutes);
+            return ToUtc(local, timeZone);
+        }
+
+        if (ev.StartUtc == default)
+            return null;
+
+        return DateTime.SpecifyKind(ev.StartUtc, DateTimeKind.Utc).AddMinutes(-leadTimeMinutes);
+    }
+
+    private static DateTime ToUtc(DateTime local, TimeZoneInfo timeZone)
+    {
+        local = DateTime.SpecifyKind(local, DateTimeKind.Unspecified);
+
+        // A spring-forward gap contains no such local instant; step onto the first one that exists rather
+        // than letting ConvertTimeToUtc throw.
+        while (timeZone.IsInvalidTime(local))
+            local = local.AddMinutes(1);
+
+        return TimeZoneInfo.ConvertTimeToUtc(local, timeZone);
+    }
+
+    /// <summary>
+    /// Identifies the occurrence inside its series. A moved occurrence produces a different key, so it has
+    /// no dispatch marker and re-arms itself; the marker left behind by the old time simply ages out.
+    /// </summary>
+    private static DateTime OccurrenceKeyOf(CachedICalEvent ev) =>
+        DateTime.SpecifyKind(ev.IsAllDay ? ev.Start.Date : ev.StartUtc, DateTimeKind.Unspecified);
+
+    private static async Task<HashSet<(int UserId, string EventUid, DateTime OccurrenceKey, int LeadTimeMinutes)>>
+        LoadDispatchedKeysAsync(
+            HomassyDbContext context,
+            int calendarId,
+            List<DueReminder> due,
+            CancellationToken cancellationToken)
+    {
+        var uids = due.Select(d => TruncateUid(d.Event.Uid)).Distinct().ToList();
+
+        var sent = await context.ExternalCalendarReminderDispatches
+            .AsNoTracking()
+            .Where(d => d.ExternalCalendarId == calendarId && uids.Contains(d.EventUid))
+            .Select(d => new { d.UserId, d.EventUid, d.OccurrenceKey, d.LeadTimeMinutes })
+            .ToListAsync(cancellationToken);
+
+        return sent
+            .Select(d => (d.UserId, d.EventUid, d.OccurrenceKey, d.LeadTimeMinutes))
+            .ToHashSet();
+    }
+
+    /// <summary>Markers only matter while their occurrence can still re-trigger; the rest are swept out.</summary>
+    private async Task PruneDispatchesAsync(HomassyDbContext context, DateTime nowUtc, CancellationToken cancellationToken)
+    {
+        if (nowUtc < _nextPruneUtc)
+            return;
+
+        _nextPruneUtc = nowUtc + PruneInterval;
+        var cutoff = nowUtc - MarkerRetention;
+
+        var removed = await context.ExternalCalendarReminderDispatches
+            .Where(d => d.SentAt < cutoff)
+            .ExecuteDeleteAsync(cancellationToken);
+
+        if (removed > 0)
+            Log.Information("Pruned {Count} expired calendar reminder marker(s)", removed);
+    }
+
+    private static List<CachedICalEvent> DeserializeEvents(CalendarState calendar)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<List<CachedICalEvent>>(calendar.CachedEventsJson, JsonOptions) ?? [];
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to deserialize cached events for calendar {CalendarId}", calendar.PublicId);
+            return [];
+        }
+    }
+
+    private static TimeZoneInfo ResolveTimeZone(UserTimeZone timeZone)
+    {
+        try
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById(timeZone.ToTimeZoneId());
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Unknown timezone {TimeZone}; falling back to UTC for calendar reminders", timeZone);
+            return TimeZoneInfo.Utc;
+        }
+    }
+
+    private static string TruncateUid(string uid) =>
+        uid.Length <= MaxEventUidLength ? uid : uid[..MaxEventUidLength];
+
+    private sealed record CalendarState(
+        int Id,
+        Guid PublicId,
+        int FamilyId,
+        string ReminderLeadTimesJson,
+        TimeOnly AllDayNotifyTime,
+        string CachedEventsJson);
+
+    private sealed record DueReminder(
+        RecipientInfo Recipient,
+        CachedICalEvent Event,
+        int LeadTimeMinutes,
+        DateTime OccurrenceKey);
+}

--- a/Homassy.Web/app/components/DataExternalCalendarCard.vue
+++ b/Homassy.Web/app/components/DataExternalCalendarCard.vue
@@ -38,6 +38,10 @@
           <span>·</span>
           <span>{{ $t('profile.family.externalCalendars.eventCount', { count: calendar.eventCount }) }}</span>
         </div>
+        <div v-if="reminderSummary" class="flex items-center gap-1.5 mt-1 text-xs text-toned">
+          <UIcon name="i-lucide-bell" class="h-3.5 w-3.5 text-amber-600 dark:text-amber-400 flex-shrink-0" />
+          <span class="truncate">{{ reminderSummary }}</span>
+        </div>
         <div v-if="calendar.lastSyncError" class="mt-1 text-xs text-red-500 flex items-center gap-1">
           <UIcon name="i-lucide-alert-circle" class="h-3.5 w-3.5 flex-shrink-0" />
           <span class="truncate">{{ calendar.lastSyncError }}</span>
@@ -73,7 +77,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import type { ExternalCalendarResponse } from '~/types/externalCalendar'
 
 const props = withDefaults(defineProps<{
@@ -92,6 +96,19 @@ const emit = defineEmits<{
 const { t } = useI18n()
 
 const isDeleteModalOpen = ref(false)
+
+// Null when reminders are off, so the row disappears rather than reading "No reminders" on every card.
+const reminderSummary = computed(() => {
+  const leadTimes = props.calendar.reminderLeadTimes
+  if (!leadTimes?.length) return null
+
+  return leadTimes
+    .map((minutes) => {
+      const { key, params } = reminderLeadTimeLabel(minutes)
+      return t(key, params)
+    })
+    .join(' · ')
+})
 
 const cardEl = ref<HTMLElement | null>(null)
 const swipe = useSwipeActions(cardEl, {

--- a/Homassy.Web/app/components/ExternalCalendarReminderSettings.vue
+++ b/Homassy.Web/app/components/ExternalCalendarReminderSettings.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="space-y-2">
+    <label class="block text-sm font-medium">{{ $t('profile.family.externalCalendars.reminders') }}</label>
+    <div class="flex flex-wrap gap-2">
+      <UButton
+        v-for="minutes in REMINDER_LEAD_TIME_PRESETS"
+        :key="minutes"
+        size="xs"
+        :color="leadTimes.includes(minutes) ? 'primary' : 'neutral'"
+        :variant="leadTimes.includes(minutes) ? 'solid' : 'outline'"
+        :aria-pressed="leadTimes.includes(minutes)"
+        @click="toggle(minutes)"
+      >
+        {{ labelFor(minutes) }}
+      </UButton>
+    </div>
+    <p class="text-xs text-muted">{{ $t('profile.family.externalCalendars.remindersHint') }}</p>
+
+    <!-- An all-day event has no time of day of its own, so it only needs an anchor once reminders are on. -->
+    <div v-if="leadTimes.length > 0" class="flex items-center gap-3 flex-wrap pt-1">
+      <label class="text-sm font-medium">{{ $t('profile.family.externalCalendars.allDayNotifyTime') }}</label>
+      <UInput
+        :model-value="allDayNotifyTime"
+        type="time"
+        class="w-32"
+        @update:model-value="(v) => emit('update:allDayNotifyTime', String(v))"
+      />
+      <p class="text-xs text-muted basis-full">{{ $t('profile.family.externalCalendars.allDayNotifyTimeHint') }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  leadTimes: number[]
+  allDayNotifyTime: string
+}>()
+
+const emit = defineEmits<{
+  'update:leadTimes': [value: number[]]
+  'update:allDayNotifyTime': [value: string]
+}>()
+
+const { t: $t } = useI18n()
+
+function labelFor(minutes: number): string {
+  const { key, params } = reminderLeadTimeLabel(minutes)
+  return $t(key, params)
+}
+
+// Reassigned rather than spliced so the parent's v-model always sees a new array.
+function toggle(minutes: number) {
+  const next = props.leadTimes.includes(minutes)
+    ? props.leadTimes.filter(m => m !== minutes)
+    : [...props.leadTimes, minutes].sort((a, b) => b - a)
+
+  emit('update:leadTimes', next)
+}
+</script>

--- a/Homassy.Web/app/pages/profile/external-calendars.vue
+++ b/Homassy.Web/app/pages/profile/external-calendars.vue
@@ -54,6 +54,10 @@
             </template>
           </div>
         </div>
+        <ExternalCalendarReminderSettings
+          v-model:lead-times="newCalReminders"
+          v-model:all-day-notify-time="newCalAllDayTime"
+        />
         <div class="flex gap-2">
           <UButton color="primary" size="sm" icon="i-lucide-plus" :loading="isAddingCalendar" :disabled="!newCalName.trim() || !newCalUrl.trim()" @click="onAddCalendar">
             {{ $t('profile.family.externalCalendars.add') }}
@@ -105,6 +109,10 @@
                 <USwitch v-model="editCalEnabled" />
               </div>
             </div>
+            <ExternalCalendarReminderSettings
+              v-model:lead-times="editCalReminders"
+              v-model:all-day-notify-time="editCalAllDayTime"
+            />
             <div class="flex gap-2">
               <UButton color="primary" size="sm" icon="i-lucide-check" :loading="isSavingCalendar" @click="onSaveEditCalendar">
                 {{ $t('common.save') }}
@@ -159,6 +167,8 @@ const showAddCalendar = ref(false)
 const newCalName = ref('')
 const newCalUrl = ref('')
 const newCalColor = ref('#3B82F6')
+const newCalReminders = ref<number[]>([])
+const newCalAllDayTime = ref(DEFAULT_ALL_DAY_NOTIFY_TIME)
 const showNewColorPicker = ref(false)
 const isAddingCalendar = ref(false)
 const syncingId = ref<string | null>(null)
@@ -167,6 +177,8 @@ const editCalName = ref('')
 const editCalUrl = ref('')
 const editCalColor = ref('#3B82F6')
 const editCalEnabled = ref(true)
+const editCalReminders = ref<number[]>([])
+const editCalAllDayTime = ref(DEFAULT_ALL_DAY_NOTIFY_TIME)
 const showEditColorPicker = ref(false)
 const isSavingCalendar = ref(false)
 
@@ -225,13 +237,17 @@ async function onAddCalendar() {
     const res = await createExternalCalendar({
       name: newCalName.value.trim(),
       iCalUrl: newCalUrl.value.trim(),
-      color: newCalColor.value
+      color: newCalColor.value,
+      reminderLeadTimes: newCalReminders.value,
+      allDayNotifyTime: newCalAllDayTime.value
     })
     if (res.success && res.data) {
       externalCalendars.value.push(res.data)
       newCalName.value = ''
       newCalUrl.value = ''
       newCalColor.value = '#3B82F6'
+      newCalReminders.value = []
+      newCalAllDayTime.value = DEFAULT_ALL_DAY_NOTIFY_TIME
       showNewColorPicker.value = false
       showAddCalendar.value = false
       toast.add({ title: $t('profile.family.externalCalendars.added'), color: 'success', icon: 'i-lucide-check-circle' })
@@ -251,6 +267,8 @@ function startEditCalendar(cal: ExternalCalendarResponse) {
   editCalUrl.value = cal.iCalUrl
   editCalColor.value = cal.color
   editCalEnabled.value = cal.isEnabled
+  editCalReminders.value = [...cal.reminderLeadTimes]
+  editCalAllDayTime.value = cal.allDayNotifyTime || DEFAULT_ALL_DAY_NOTIFY_TIME
   showEditColorPicker.value = false
 }
 
@@ -262,7 +280,9 @@ async function onSaveEditCalendar() {
       name: editCalName.value.trim(),
       iCalUrl: editCalUrl.value.trim(),
       color: editCalColor.value,
-      isEnabled: editCalEnabled.value
+      isEnabled: editCalEnabled.value,
+      reminderLeadTimes: editCalReminders.value,
+      allDayNotifyTime: editCalAllDayTime.value
     })
     if (res.success && res.data) {
       const idx = externalCalendars.value.findIndex(c => c.publicId === editingCalId.value)

--- a/Homassy.Web/app/types/externalCalendar.ts
+++ b/Homassy.Web/app/types/externalCalendar.ts
@@ -7,12 +7,18 @@ export interface ExternalCalendarResponse {
   lastSyncedAt: string | null
   lastSyncError: string | null
   eventCount: number
+  /** Minutes before an event starts; 0 means "at start". Empty = reminders off. */
+  reminderLeadTimes: number[]
+  /** `HH:mm` an all-day event's reminder is anchored to, in each member's own timezone. */
+  allDayNotifyTime: string
 }
 
 export interface CreateExternalCalendarRequest {
   name: string
   iCalUrl: string
   color: string
+  reminderLeadTimes?: number[]
+  allDayNotifyTime?: string
 }
 
 export interface UpdateExternalCalendarRequest {
@@ -20,4 +26,7 @@ export interface UpdateExternalCalendarRequest {
   iCalUrl?: string
   color?: string
   isEnabled?: boolean
+  /** Omit to leave reminders unchanged; send an empty array to turn them off. */
+  reminderLeadTimes?: number[]
+  allDayNotifyTime?: string
 }

--- a/Homassy.Web/app/utils/calendarReminders.ts
+++ b/Homassy.Web/app/utils/calendarReminders.ts
@@ -1,0 +1,20 @@
+/** Lead times offered in the external calendar settings form, in minutes before the event starts. */
+export const REMINDER_LEAD_TIME_PRESETS = [0, 5, 15, 30, 60, 1440]
+
+/** Mirrors the API's default for `FamilyExternalCalendar.AllDayNotifyTime`. */
+export const DEFAULT_ALL_DAY_NOTIFY_TIME = '08:00'
+
+/**
+ * i18n key + params for a reminder lead time, so the settings form and the calendar card word it the
+ * same way. Falls back to minutes for any value that is not a whole number of hours or days (the API
+ * accepts arbitrary minutes, the presets are only a shortcut).
+ */
+export function reminderLeadTimeLabel(minutes: number): { key: string, params: Record<string, number> } {
+  const base = 'profile.family.externalCalendars'
+
+  if (minutes === 0) return { key: `${base}.leadAtStart`, params: {} }
+  if (minutes % 1440 === 0) return { key: `${base}.leadDays`, params: { count: minutes / 1440 } }
+  if (minutes % 60 === 0) return { key: `${base}.leadHours`, params: { count: minutes / 60 } }
+
+  return { key: `${base}.leadMinutes`, params: { count: minutes } }
+}

--- a/Homassy.Web/i18n/locales/de.json
+++ b/Homassy.Web/i18n/locales/de.json
@@ -1011,7 +1011,15 @@
         "synced": "Kalender synchronisiert",
         "syncFailed": "Synchronisierung fehlgeschlagen",
         "deleteTitle": "Kalender löschen",
-        "deleteWarning": "Möchtest du diesen externen Kalender wirklich löschen?"
+        "deleteWarning": "Möchtest du diesen externen Kalender wirklich löschen?",
+        "reminders": "Erinnerungen",
+        "remindersHint": "Wähle, wie lange vor dem Beginn eines Termins aus diesem Kalender du erinnert werden möchtest. Erinnerungen gehen an alle Familienmitglieder, die Push-Benachrichtigungen aktiviert haben.",
+        "leadAtStart": "Bei Beginn",
+        "leadMinutes": "{count} Min. vorher",
+        "leadHours": "{count} Std. vorher",
+        "leadDays": "{count} Tag(e) vorher",
+        "allDayNotifyTime": "Uhrzeit für ganztägige Termine",
+        "allDayNotifyTimeHint": "Ganztägige Termine haben keine Startzeit, daher richtet sich ihre Erinnerung nach dieser Uhrzeit – jeweils in der Zeitzone des Mitglieds."
       }
     },
     "settingsProfileSection": "Profilinformationen",

--- a/Homassy.Web/i18n/locales/en.json
+++ b/Homassy.Web/i18n/locales/en.json
@@ -1011,7 +1011,15 @@
         "synced": "Calendar synced",
         "syncFailed": "Sync failed",
         "deleteTitle": "Delete calendar",
-        "deleteWarning": "Are you sure you want to delete this external calendar?"
+        "deleteWarning": "Are you sure you want to delete this external calendar?",
+        "reminders": "Reminders",
+        "remindersHint": "Pick when to be reminded before an event from this calendar starts. Reminders are pushed to family members who have push notifications enabled.",
+        "leadAtStart": "At start",
+        "leadMinutes": "{count} min before",
+        "leadHours": "{count} h before",
+        "leadDays": "{count} day before",
+        "allDayNotifyTime": "All-day event time",
+        "allDayNotifyTimeHint": "All-day events have no start time, so their reminder is anchored to this time in each member's own timezone."
       }
     },
     "settingsProfileSection": "Profile Information",

--- a/Homassy.Web/i18n/locales/hu.json
+++ b/Homassy.Web/i18n/locales/hu.json
@@ -1014,7 +1014,15 @@
         "synced": "Naptár szinkronizálva",
         "syncFailed": "Szinkronizálás sikertelen",
         "deleteTitle": "Naptár törlése",
-        "deleteWarning": "Biztosan törölni szeretnéd ezt a külső naptárat?"
+        "deleteWarning": "Biztosan törölni szeretnéd ezt a külső naptárat?",
+        "reminders": "Emlékeztetők",
+        "remindersHint": "Válaszd ki, mennyivel korábban kapj emlékeztetőt a naptár eseményei előtt. Az emlékeztetőt azok a családtagok kapják meg, akiknél a push értesítés be van kapcsolva.",
+        "leadAtStart": "Kezdéskor",
+        "leadMinutes": "{count} perccel előbb",
+        "leadHours": "{count} órával előbb",
+        "leadDays": "{count} nappal előbb",
+        "allDayNotifyTime": "Egész napos esemény ideje",
+        "allDayNotifyTimeHint": "Az egész napos eseményeknek nincs kezdési idejük, ezért az emlékeztető ehhez az időponthoz igazodik, minden családtag saját időzónájában."
       }
     },
     "settingsProfileSection": "Profil adatok",


### PR DESCRIPTION
Closes #61.

Events pulled from the synced external (iCal) calendars can now trigger push reminders.

## Configuration

Per calendar (`FamilyExternalCalendar`):

- `ReminderLeadTimesJson` — JSON minute array, `0` = at start. Multiple lead times per calendar are supported (e.g. `[1440, 15]`). Null/empty = reminders off.
- `AllDayNotifyTime` — an all-day event has no start time to count back from, so its reminder is anchored to this time of day instead of midnight. Defaults to `08:00`.

The API exposes these as `reminderLeadTimes: number[]` and `allDayNotifyTime: "HH:mm"`. On update, omitting `reminderLeadTimes` leaves them unchanged; sending an empty array turns reminders off. Lead times are validated (max 8, distinct, 0 minutes to 30 days) with a new `EXTCAL-0006` error code.

## Delivery

`ExternalCalendarReminderService` (Homassy.Notifications) polls every minute — the iCal sync stays hourly, but an "at start" reminder must not wait on it. Recipients are resolved through the existing `FamilyPushNotifier`, so only family members with push notifications enabled and a live subscription are notified.

Trigger times:

- **Timed event** — `StartUtc - leadTime`. Absolute, so identical for every member.
- **All-day event** — the calendar's notify time in **each recipient's own timezone** (`UserProfile.DefaultTimeZone`), shifted back by the lead time. Members in different zones are reminded at their local morning. A notify time that falls inside a DST spring-forward gap steps onto the first valid instant rather than throwing.

Reminders whose trigger already passed are still delivered within a 15-minute catch-up window, so a deploy or restart does not swallow them; anything older is dropped as stale.

## At-most-once

A new `ExternalCalendarReminderDispatches` table records each sent reminder, keyed by (calendar, user, event UID, occurrence, lead time) behind a unique index. The worker claims the row and commits it **before** pushing, so a re-sync, a worker restart inside the catch-up window, or a lost race between instances can only skip a send — never repeat one.

Moved and deleted events fall out of this for free: the occurrence key changes when an event moves, so the moved occurrence has no marker and re-arms itself, and a deleted event stops appearing in the synced cache and never fires. Markers are pruned after 30 days.

## Cached event shape

`CachedICalEvent.StartUtc` is new. The existing `Start` comes from Ical.Net's `AsSystemLocal` — server-local with no offset — so it cannot be scheduled against. Entries cached before this field existed deserialize to `default` and are skipped until the next sync backfills them (the sync also runs on API startup, so that is immediate on deploy).

## Frontend

Reminder configuration in the external calendar settings form (`ExternalCalendarReminderSettings`: lead-time preset chips + the all-day time input), with a reminder summary row on the calendar card. New i18n keys in all three locales.

## Notes

- Only the push channel is wired up. Email and in-app were left out deliberately — in-app has no storage or UI behind `UserNotificationPreferences.InAppNotificationsEnabled` today, so it would need its own entity, endpoint and UI.
- `Homassy.Tests` does not compile on `master` (96 errors in `ShoppingListActivityMonitorServiceTests` and `GracefulShutdownTests`, from an earlier rename). This branch adds no new errors, but it also means the suite could not be run. Verified instead with the trigger/timezone/DST maths exercised directly against the shipped code, plus `dotnet build`, `eslint`, `nuxi typecheck` and a production `npm run build`.