### PR TITLE
feat(calendar): add family-shared day notes

### DIFF
--- a/Homassy.API/Attributes/Validation/SafeFreeTextAttribute.cs
+++ b/Homassy.API/Attributes/Validation/SafeFreeTextAttribute.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Homassy.API.Attributes.Validation
+{
+    /// <summary>
+    /// Blocks the script-injection patterns <see cref="SanitizedStringAttribute"/> blocks, but — unlike it —
+    /// tolerates bare <c>&lt;</c> and <c>&gt;</c> characters.
+    /// <para>
+    /// <see cref="SanitizedStringAttribute"/> rejects a value whenever HTML-encoding would change it *and* it
+    /// contains an angle bracket, which is correct for a short label but wrong for prose: a legitimate note
+    /// reading "tartsd 5 °C &lt; alatt" or "apply if x &gt; 3" would be refused with an opaque
+    /// "potentially dangerous content" error. Use this attribute on free-text fields instead.
+    /// </para>
+    /// <para>
+    /// Nothing is lost by allowing the brackets through: the values are rendered as text (Vue escapes by
+    /// default and never uses <c>v-html</c> for them) and reach push notifications as plain text. The
+    /// dangerous-pattern blocklist below is what actually stops an injection attempt.
+    /// </para>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    public class SafeFreeTextAttribute : ValidationAttribute
+    {
+        private static readonly string[] DangerousPatterns =
+        [
+            "<script",
+            "javascript:",
+            "onerror=",
+            "onload=",
+            "onclick=",
+            "onmouseover=",
+            "onfocus=",
+            "onblur=",
+            "eval(",
+            "expression(",
+            "vbscript:",
+            "data:text/html"
+        ];
+
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+        {
+            if (value is null)
+            {
+                return ValidationResult.Success;
+            }
+
+            if (value is not string stringValue)
+            {
+                return new ValidationResult($"The field {validationContext.DisplayName} must be a string.");
+            }
+
+            if (string.IsNullOrWhiteSpace(stringValue))
+            {
+                return ValidationResult.Success;
+            }
+
+            var lowerValue = stringValue.ToLowerInvariant();
+
+            foreach (var pattern in DangerousPatterns)
+            {
+                if (lowerValue.Contains(pattern))
+                {
+                    return new ValidationResult($"The field {validationContext.DisplayName} contains potentially dangerous content.");
+                }
+            }
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/Homassy.API/Constants/CalendarConstants.cs
+++ b/Homassy.API/Constants/CalendarConstants.cs
@@ -1,0 +1,12 @@
+namespace Homassy.API.Constants
+{
+    public static class CalendarConstants
+    {
+        /// <summary>
+        /// Longest date range a single calendar read may cover. Shared by every calendar-surface controller so
+        /// they cannot drift: if only one were widened, the calendar screen would start getting 400s from that
+        /// endpoint while the others kept working — a confusing partial failure.
+        /// </summary>
+        public const int MaxDateRangeDays = 93;
+    }
+}

--- a/Homassy.API/Constants/ErrorCodeDescriptions.cs
+++ b/Homassy.API/Constants/ErrorCodeDescriptions.cs
@@ -102,7 +102,15 @@ public static class ErrorCodeDescriptions
         [ErrorCodes.ExternalCalendarAccessDenied] = "Access denied to this external calendar.",
         [ErrorCodes.ExternalCalendarInvalidUrl] = "The provided URL is not a valid iCal feed.",
         [ErrorCodes.ExternalCalendarFetchFailed] = "Failed to fetch the iCal feed from the provided URL.",
-        [ErrorCodes.ExternalCalendarRequiresFamily] = "You must be a member of a family to manage external calendars."
+        [ErrorCodes.ExternalCalendarRequiresFamily] = "You must be a member of a family to manage external calendars.",
+
+        // Calendar Note Errors
+        [ErrorCodes.CalendarNoteNotFound] = "Calendar note not found.",
+        [ErrorCodes.CalendarNoteAccessDenied] = "Access denied to this calendar note.",
+        [ErrorCodes.CalendarNoteRequiresFamily] = "You must be a member of a family to manage calendar notes.",
+        [ErrorCodes.CalendarNoteInvalidDate] = "The note date is missing or invalid.",
+        [ErrorCodes.CalendarNoteInvalidReminder] = "The reminder settings are invalid.",
+        [ErrorCodes.CalendarNoteConcurrencyConflict] = "The note was changed by someone else; reload it and try again."
     }.ToFrozenDictionary();
 
     public static IReadOnlyList<ErrorCodeInfo> GetAllErrorCodes()

--- a/Homassy.API/Constants/TableNames.cs
+++ b/Homassy.API/Constants/TableNames.cs
@@ -26,5 +26,6 @@
         public const string ItemAutomationExecutions = "ItemAutomationExecutions";
 
         public const string FamilyExternalCalendars = "FamilyExternalCalendars";
+        public const string CalendarNotes = "CalendarNotes";
     }
 }

--- a/Homassy.API/Context/HomassyDbContext.cs
+++ b/Homassy.API/Context/HomassyDbContext.cs
@@ -119,6 +119,48 @@ namespace Homassy.API.Context
             });
             #endregion
 
+            #region CalendarNote Relationships
+            modelBuilder.Entity<CalendarNote>(entity =>
+            {
+                entity.HasOne(n => n.Family)
+                    .WithMany()
+                    .HasForeignKey(n => n.FamilyId)
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                // Restrict, and no navigation property: a note is family data, so losing a member must not
+                // delete the notes they wrote for everyone, and a required navigation to a soft-delete-filtered
+                // principal would make EF log a query-filter warning on every model build.
+                entity.HasOne<User>()
+                    .WithMany()
+                    .HasForeignKey(n => n.CreatedByUserId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                entity.HasOne<User>()
+                    .WithMany()
+                    .HasForeignKey(n => n.LastEditedByUserId)
+                    .OnDelete(DeleteBehavior.Restrict);
+
+                // A note is attached to a calendar day, not an instant: `date` carries no timezone, so every
+                // member sees the same day no matter where they are.
+                entity.Property(e => e.Date).HasColumnType("date");
+
+                // The hot path: one family, one week-to-quarter range. Covers a FamilyId-only lookup too.
+                entity.HasIndex(e => new { e.FamilyId, e.Date });
+
+                // Supports the reminder worker's every-minute due scan. Partial, because almost every note
+                // either has no reminder or has already fired — the index holds only pending reminders and
+                // shrinks back as they are claimed. The filter mirrors the worker's WHERE clause exactly
+                // (`IsDeleted = false` comes from the global query filter) so PostgreSQL can actually use it.
+                entity.HasIndex(e => e.ReminderAt)
+                    .HasDatabaseName("IX_CalendarNotes_PendingReminder")
+                    .HasFilter("\"ReminderAt\" IS NOT NULL AND \"ReminderSentAt\" IS NULL AND \"IsDeleted\" = false");
+
+                // The token round-trips through the client (see CalendarNoteFunctions), which is what makes it
+                // catch a lost update across two requests rather than only within one.
+                entity.Property(e => e.RowVersion).IsConcurrencyToken();
+            });
+            #endregion
+
             #region FamilyJoinRequest Relationships
             modelBuilder.Entity<FamilyJoinRequest>(entity =>
             {
@@ -280,6 +322,7 @@ namespace Homassy.API.Context
         public DbSet<Family> Families { get; set; }
         public DbSet<FamilyJoinRequest> FamilyJoinRequests { get; set; }
         public DbSet<FamilyExternalCalendar> FamilyExternalCalendars { get; set; }
+        public DbSet<CalendarNote> CalendarNotes { get; set; }
         #endregion
 
         #region Product Related DbSets

--- a/Homassy.API/Controllers/CLAUDE.md
+++ b/Homassy.API/Controllers/CLAUDE.md
@@ -392,6 +392,33 @@ Aggregates calendar events (inventory expirations, automation executions, shoppi
 - Dates are converted to UTC day boundaries before querying
 - Backed by `CalendarFunctions`; returns `List<CalendarEventInfo>`
 
+### CalendarNoteController
+
+Family-shared day notes on the calendar — free text attached to a single day, with an optional reminder (requires `[Authorize]`).
+
+**Endpoints:**
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/?startDate=&endDate=` | Get the family's notes for a date range |
+| POST | `/` | Create a note |
+| PUT | `/{publicId}` | Update a note (partial) |
+| DELETE | `/{publicId}` | Delete a note (soft delete) |
+
+**Key Patterns:**
+- Backed by `CalendarNoteFunctions`; persisted as `CalendarNote` (family-scoped only, like `FamilyExternalCalendar`, and likewise **not** cached in memory)
+- The range read is a **GET with query params**, unlike `CalendarController`'s POST-with-body: `POST /` is needed here for creating a note. Same 93-day cap, hoisted to `CalendarConstants.MaxDateRangeDays` so the two cannot drift
+- `Date` is a `DateOnly` → `date` column, so every member sees the same day regardless of timezone. The JSON contract is a bare `YYYY-MM-DD` — no `Z`, no time component
+- The read returns an **empty list** for a user with no family (their calendar still works); writes throw `CALNOTE-0003`
+- Author and last editor are explicit FK columns (`CreatedByUserId` / `LastEditedByUserId`, `DeleteBehavior.Restrict`, no navigation properties) rather than `RecordChange.LastModifiedBy`, which is unjoinable JSON, holds only the last modifier, and is overwritten by `DeleteRecord`. Display names resolve through `UserFunctions`' caches, so a whole range costs no extra queries
+- **Optimistic concurrency**: the response carries an opaque `version`; the update request must echo it. A mismatch is **409** `CALNOTE-0006`. The token is a `RowVersion` GUID re-rolled on each user edit — the reminder worker's claim deliberately does not bump it, so a fired reminder never invalidates an open form
+- Partial-patch conventions: `null` means "no change"; `Content: ""` **erases** the body; the reminder needs `ClearReminder: true` to be removed (a null `ReminderTime` means "no change", and `""` would reach the time parser as an accidental 400). Sending `ClearReminder` together with a `ReminderTime` is rejected
+- **Reminder**: the client sends a wall-clock `ReminderTime` (`HH:mm`); the server combines it with the note's date **in the author's timezone** to derive the absolute `ReminderAt`. The intent (`ReminderTimeOfDay` + a snapshot of `ReminderTimeZone`) is stored alongside so a later date change can be recomputed deterministically. Delivery is push-only, by `CalendarNoteReminderService` in `Homassy.Notifications`
+- Create/update/delete are logged to the activity feed (`ActivityType` 30–32). Note that the activity lands on *today*, while the note lands on its own date — the two markers legitimately sit on different calendar days
+
+**Realtime (SignalR):**
+- `CalendarNoteUpserted` / `CalendarNoteDeleted` on the master-data hub, family group only (the `ExternalCalendar*` pattern). Upsert carries the full DTO, delete carries `{ publicId }`; a no-op PUT broadcasts nothing
+
 ### StatisticsController
 
 Exposes nightly-cached, global (platform-wide) counts (no authentication — `[AllowAnonymous]`).

--- a/Homassy.API/Controllers/CalendarController.cs
+++ b/Homassy.API/Controllers/CalendarController.cs
@@ -1,4 +1,5 @@
 using Asp.Versioning;
+using Homassy.API.Constants;
 using Homassy.API.Enums;
 using Homassy.API.Functions;
 using Homassy.API.Models.Calendar;
@@ -17,7 +18,7 @@ namespace Homassy.API.Controllers
     [Authorize]
     public class CalendarController : ControllerBase
     {
-        private const int MaxDateRangeDays = 93;
+        private const int MaxDateRangeDays = CalendarConstants.MaxDateRangeDays;
 
         /// <summary>
         /// Gets all calendar events (inventory expirations, automation executions, shopping list deadlines)

--- a/Homassy.API/Controllers/CalendarNoteController.cs
+++ b/Homassy.API/Controllers/CalendarNoteController.cs
@@ -1,0 +1,95 @@
+using Asp.Versioning;
+using Homassy.API.Constants;
+using Homassy.API.Functions;
+using Homassy.API.Models.CalendarNote;
+using Homassy.API.Models.Common;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Homassy.API.Controllers
+{
+    /// <summary>
+    /// Family-shared day notes on the calendar.
+    /// </summary>
+    [ApiVersion(1.0)]
+    [Route("api/v{version:apiVersion}/[controller]")]
+    [ApiController]
+    [Authorize]
+    public class CalendarNoteController : ControllerBase
+    {
+        private const int MaxDateRangeDays = CalendarConstants.MaxDateRangeDays;
+
+        /// <summary>
+        /// Gets the family's notes for a date range. A user with no family gets an empty list, not an error.
+        /// </summary>
+        /// <remarks>
+        /// A GET with query params rather than <c>CalendarController</c>'s POST-with-body: this controller needs
+        /// <c>POST /</c> for creating a note, and a hot range read gets compression and caching for free over GET.
+        /// </remarks>
+        [HttpGet]
+        [MapToApiVersion(1.0)]
+        [ProducesResponseType(typeof(ApiResponse<List<CalendarNoteResponse>>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> GetCalendarNotes(
+            [FromQuery] GetCalendarNotesRequest request,
+            CancellationToken cancellationToken)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ApiResponse.ErrorResponse(Enums.ErrorCodes.ValidationInvalidRequest));
+
+            if (request.StartDate is not { } startDate || request.EndDate is not { } endDate)
+                return BadRequest(ApiResponse.ErrorResponse(Enums.ErrorCodes.ValidationInvalidRequest));
+
+            if (endDate < startDate || (endDate.DayNumber - startDate.DayNumber) > MaxDateRangeDays)
+                return BadRequest(ApiResponse.ErrorResponse(Enums.ErrorCodes.ValidationInvalidRequest));
+
+            var notes = await new CalendarNoteFunctions().GetCalendarNotesAsync(startDate, endDate, cancellationToken);
+            return Ok(ApiResponse<List<CalendarNoteResponse>>.SuccessResponse(notes));
+        }
+
+        [HttpPost]
+        [MapToApiVersion(1.0)]
+        [ProducesResponseType(typeof(ApiResponse<CalendarNoteResponse>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> CreateCalendarNote(
+            [FromBody] CreateCalendarNoteRequest request,
+            CancellationToken cancellationToken)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ApiResponse.ErrorResponse(Enums.ErrorCodes.ValidationInvalidRequest));
+
+            var note = await new CalendarNoteFunctions().CreateCalendarNoteAsync(request, cancellationToken);
+            return Ok(ApiResponse<CalendarNoteResponse>.SuccessResponse(note));
+        }
+
+        [HttpPut("{publicId:guid}")]
+        [MapToApiVersion(1.0)]
+        [ProducesResponseType(typeof(ApiResponse<CalendarNoteResponse>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status409Conflict)]
+        public async Task<IActionResult> UpdateCalendarNote(
+            Guid publicId,
+            [FromBody] UpdateCalendarNoteRequest request,
+            CancellationToken cancellationToken)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ApiResponse.ErrorResponse(Enums.ErrorCodes.ValidationInvalidRequest));
+
+            var note = await new CalendarNoteFunctions().UpdateCalendarNoteAsync(publicId, request, cancellationToken);
+            return Ok(ApiResponse<CalendarNoteResponse>.SuccessResponse(note));
+        }
+
+        [HttpDelete("{publicId:guid}")]
+        [MapToApiVersion(1.0)]
+        [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> DeleteCalendarNote(Guid publicId, CancellationToken cancellationToken)
+        {
+            await new CalendarNoteFunctions().DeleteCalendarNoteAsync(publicId, cancellationToken);
+            return Ok(ApiResponse.SuccessResponse("Calendar note deleted"));
+        }
+    }
+}

--- a/Homassy.API/Entities/Family/CalendarNote.cs
+++ b/Homassy.API/Entities/Family/CalendarNote.cs
@@ -1,0 +1,93 @@
+using Homassy.API.Entities.Common;
+using Homassy.API.Enums;
+using System.ComponentModel.DataAnnotations;
+
+namespace Homassy.API.Entities.Family
+{
+    /// <summary>
+    /// A free-text note a family member attaches to a single calendar day, visible to the whole family.
+    /// Optionally carries a reminder that pushes a notification to every member at one absolute instant.
+    /// </summary>
+    /// <remarks>
+    /// The user foreign keys use <see cref="Microsoft.EntityFrameworkCore.DeleteBehavior.Restrict"/>: a note is
+    /// *family* data, so losing a member must not delete the notes they wrote for everyone. Users are only ever
+    /// soft-deleted, so this never fires in practice — it just makes a hypothetical hard delete fail loudly
+    /// instead of shredding family history. Neither user FK has a navigation property, because a required
+    /// navigation to a soft-delete-filtered principal makes EF log a query-filter warning on every model build.
+    /// </remarks>
+    public class CalendarNote : RecordChangeEntity
+    {
+        public int FamilyId { get; set; }
+        public Family Family { get; set; } = null!;
+
+        /// <summary>
+        /// The day the note is about. Deliberately <see cref="DateOnly"/> (a <c>date</c> column, no timezone):
+        /// a <c>timestamptz</c> would be reinterpreted per session timezone, so a note written for "March 15"
+        /// in Budapest could read as March 14 in New York — which breaks "visible to every family member".
+        /// </summary>
+        public DateOnly Date { get; set; }
+
+        [Required]
+        [StringLength(128, MinimumLength = 1)]
+        public required string Title { get; set; }
+
+        /// <summary>
+        /// Optional body. Null rather than <c>""</c> when absent, so "no content" has a single representation.
+        /// </summary>
+        [StringLength(2000)]
+        public string? Content { get; set; }
+
+        /// <summary>
+        /// The wall-clock time the author picked. Stored alongside <see cref="ReminderAt"/> because the instant
+        /// alone cannot be converted back to a wall-clock time without knowing which zone to go through — which
+        /// is exactly what a later change to <see cref="Date"/> needs.
+        /// </summary>
+        public TimeOnly? ReminderTimeOfDay { get; set; }
+
+        /// <summary>
+        /// Snapshot of the author's timezone, taken when the reminder is first set and kept on later edits. That
+        /// keeps the reminder anchored where the author intended: a member in another zone editing the note (or
+        /// the author later changing their profile timezone) must not silently move it.
+        /// </summary>
+        [EnumDataType(typeof(UserTimeZone))]
+        public UserTimeZone? ReminderTimeZone { get; set; }
+
+        /// <summary>
+        /// Absolute instant the reminder fires, derived from <see cref="Date"/> + <see cref="ReminderTimeOfDay"/>
+        /// + <see cref="ReminderTimeZone"/>. Indexed (partially) because the worker scans it every minute.
+        /// </summary>
+        public DateTime? ReminderAt { get; set; }
+
+        /// <summary>
+        /// At-most-once claim marker. The worker commits this <em>before</em> pushing, so a crash or a lost race
+        /// can only ever skip a send, never repeat one.
+        /// </summary>
+        public DateTime? ReminderSentAt { get; set; }
+
+        /// <summary>
+        /// The author. An explicit column rather than <c>RecordChange.LastModifiedBy</c>, which is unjoinable
+        /// JSON, holds only the *last* modifier, and gets overwritten by <c>DeleteRecord</c>.
+        /// </summary>
+        public int CreatedByUserId { get; set; }
+
+        /// <summary>Initialised to the author on create, so the response DTO never needs a null branch.</summary>
+        public int LastEditedByUserId { get; set; }
+
+        public DateTime CreatedAt { get; set; }
+
+        /// <summary>Null until the note is actually edited — that is how the UI knows to show an editor line.</summary>
+        public DateTime? LastEditedAt { get; set; }
+
+        /// <summary>
+        /// Optimistic-concurrency token, re-rolled on every user edit and echoed by the client so a stale form
+        /// cannot silently overwrite another member's change.
+        /// <para>
+        /// An explicit column rather than PostgreSQL's <c>xmin</c>: Npgsql dropped its <c>xmin</c> helper, and
+        /// hand-declaring the system column makes EF's migration try to CREATE it. Keeping it explicit also means
+        /// the reminder worker's <c>ReminderSentAt</c> claim — which bypasses change tracking — deliberately does
+        /// *not* bump the token, so a fired reminder never invalidates a form someone has open.
+        /// </para>
+        /// </summary>
+        public Guid RowVersion { get; set; }
+    }
+}

--- a/Homassy.API/Enums/ActivityType.cs
+++ b/Homassy.API/Enums/ActivityType.cs
@@ -45,6 +45,11 @@ namespace Homassy.API.Enums
         // Family Join Request Activities (27-29)
         FamilyJoinRequestCreate = 27,
         FamilyJoinRequestApprove = 28,
-        FamilyJoinRequestDecline = 29
+        FamilyJoinRequestDecline = 29,
+
+        // Calendar Note Activities (30-32)
+        CalendarNoteCreate = 30,
+        CalendarNoteUpdate = 31,
+        CalendarNoteDelete = 32
     }
 }

--- a/Homassy.API/Enums/ErrorCode.cs
+++ b/Homassy.API/Enums/ErrorCode.cs
@@ -114,4 +114,13 @@ public static class ErrorCodes
     public const string ExternalCalendarFetchFailed = "EXTCAL-0004";
     public const string ExternalCalendarRequiresFamily = "EXTCAL-0005";
     #endregion
+
+    #region Calendar Note Errors (CALNOTE-0xxx)
+    public const string CalendarNoteNotFound = "CALNOTE-0001";
+    public const string CalendarNoteAccessDenied = "CALNOTE-0002";
+    public const string CalendarNoteRequiresFamily = "CALNOTE-0003";
+    public const string CalendarNoteInvalidDate = "CALNOTE-0004";
+    public const string CalendarNoteInvalidReminder = "CALNOTE-0005";
+    public const string CalendarNoteConcurrencyConflict = "CALNOTE-0006";
+    #endregion
 }

--- a/Homassy.API/Exceptions/CalendarNoteException.cs
+++ b/Homassy.API/Exceptions/CalendarNoteException.cs
@@ -1,0 +1,50 @@
+using Homassy.API.Enums;
+
+namespace Homassy.API.Exceptions
+{
+    public class CalendarNoteNotFoundException : Exception
+    {
+        public string ErrorCode { get; } = ErrorCodes.CalendarNoteNotFound;
+
+        public CalendarNoteNotFoundException(string message = "Calendar note not found") : base(message) { }
+    }
+
+    public class CalendarNoteAccessDeniedException : Exception
+    {
+        public string ErrorCode { get; } = ErrorCodes.CalendarNoteAccessDenied;
+
+        public CalendarNoteAccessDeniedException(string message = "Access denied to this calendar note") : base(message) { }
+    }
+
+    public class CalendarNoteRequiresFamilyException : Exception
+    {
+        public string ErrorCode { get; } = ErrorCodes.CalendarNoteRequiresFamily;
+
+        public CalendarNoteRequiresFamilyException(string message = "You must be a member of a family to manage calendar notes") : base(message) { }
+    }
+
+    public class CalendarNoteInvalidDateException : Exception
+    {
+        public string ErrorCode { get; } = ErrorCodes.CalendarNoteInvalidDate;
+
+        public CalendarNoteInvalidDateException(string message = "Invalid note date") : base(message) { }
+    }
+
+    public class CalendarNoteInvalidReminderException : Exception
+    {
+        public string ErrorCode { get; } = ErrorCodes.CalendarNoteInvalidReminder;
+
+        public CalendarNoteInvalidReminderException(string message = "Invalid reminder settings") : base(message) { }
+    }
+
+    /// <summary>
+    /// The note changed between the client reading it and submitting its edit. Surfaces as 409 so the client
+    /// can reload rather than silently overwriting the other member's change.
+    /// </summary>
+    public class CalendarNoteConcurrencyException : Exception
+    {
+        public string ErrorCode { get; } = ErrorCodes.CalendarNoteConcurrencyConflict;
+
+        public CalendarNoteConcurrencyException(string message = "The calendar note was modified by someone else") : base(message) { }
+    }
+}

--- a/Homassy.API/Extensions/UserTimeZoneExtensions.cs
+++ b/Homassy.API/Extensions/UserTimeZoneExtensions.cs
@@ -1,9 +1,50 @@
 ﻿using Homassy.API.Enums;
+using Serilog;
 
 namespace Homassy.API.Extensions
 {
     public static class UserTimeZoneExtensions
     {
+        /// <summary>
+        /// Resolves the zone, falling back to UTC so an id the host cannot map takes down neither a request
+        /// nor a background worker.
+        /// </summary>
+        public static TimeZoneInfo ToTimeZoneInfo(this UserTimeZone timeZone)
+        {
+            try
+            {
+                return TimeZoneInfo.FindSystemTimeZoneById(timeZone.ToTimeZoneId());
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Unknown timezone {TimeZone}; falling back to UTC", timeZone);
+                return TimeZoneInfo.Utc;
+            }
+        }
+
+        /// <summary>
+        /// Converts a wall-clock local time to its absolute UTC instant.
+        /// <para>
+        /// A local time inside a DST spring-forward gap does not exist, and
+        /// <see cref="TimeZoneInfo.ConvertTimeToUtc(DateTime, TimeZoneInfo)"/> throws on it, so the value is
+        /// nudged forward onto the first instant that does exist (a 02:30 reminder on the gap day fires at
+        /// 03:00). An *ambiguous* local time — the fall-back hour, which happens twice — is left to
+        /// <c>ConvertTimeToUtc</c>, which silently picks the standard offset. That is deliberate: the reminder
+        /// fires once, at the later 02:30, which is the reasonable reading of "02:30 that day".
+        /// </para>
+        /// </summary>
+        public static DateTime LocalToUtc(this TimeZoneInfo timeZone, DateTime local)
+        {
+            local = DateTime.SpecifyKind(local, DateTimeKind.Unspecified);
+
+            while (timeZone.IsInvalidTime(local))
+            {
+                local = local.AddMinutes(1);
+            }
+
+            return TimeZoneInfo.ConvertTimeToUtc(local, timeZone);
+        }
+
         public static string ToTimeZoneId(this UserTimeZone timeZone)
         {
             return timeZone switch

--- a/Homassy.API/Functions/CalendarNoteFunctions.cs
+++ b/Homassy.API/Functions/CalendarNoteFunctions.cs
@@ -1,0 +1,339 @@
+using Homassy.API.Context;
+using Homassy.API.Enums;
+using Homassy.API.Exceptions;
+using Homassy.API.Extensions;
+using Homassy.API.Hubs;
+using Homassy.API.Models.CalendarNote;
+using Microsoft.EntityFrameworkCore;
+using Serilog;
+using System.Globalization;
+using CalendarNoteEntity = Homassy.API.Entities.Family.CalendarNote;
+
+namespace Homassy.API.Functions
+{
+    /// <summary>
+    /// Family-shared day notes. Deliberately cache-free (like external calendars): notes are range-queried by
+    /// date, unbounded in count and mutated by every member, so an in-memory mirror would buy nothing.
+    /// </summary>
+    public class CalendarNoteFunctions
+    {
+        /// <summary>
+        /// A reminder whose instant has already passed is still delivered inside this window. Shared with
+        /// <c>CalendarNoteReminderService</c> in Homassy.Notifications so the write-time "already stale" check
+        /// and the worker's delivery window can never diverge.
+        /// </summary>
+        public static readonly TimeSpan ReminderCatchUpWindow = TimeSpan.FromMinutes(15);
+
+        /// <summary>Backstop on a single range read; a family with more notes than this in one range is not real.</summary>
+        private const int MaxNotesPerRange = 1000;
+
+        public async Task<List<CalendarNoteResponse>> GetCalendarNotesAsync(
+            DateOnly startDate,
+            DateOnly endDate,
+            CancellationToken ct = default)
+        {
+            var familyId = SessionInfo.GetFamilyId();
+
+            // A user with no family still has a working calendar (inventory, automations and shopping deadlines
+            // are all user-scoped), so an empty list beats an exception that would break the whole page. Writes
+            // do throw — see CreateCalendarNoteAsync.
+            if (familyId == null)
+                return [];
+
+            using var context = new HomassyDbContext();
+
+            var notes = await context.CalendarNotes
+                .AsNoTracking()
+                .Where(n => n.FamilyId == familyId.Value && n.Date >= startDate && n.Date <= endDate)
+                .OrderBy(n => n.Date)
+                .ThenBy(n => n.Id)
+                .Take(MaxNotesPerRange)
+                .ToListAsync(ct);
+
+            var userFunctions = new UserFunctions();
+            return notes.Select(n => MapToResponse(n, userFunctions)).ToList();
+        }
+
+        public async Task<CalendarNoteResponse> CreateCalendarNoteAsync(
+            CreateCalendarNoteRequest request,
+            CancellationToken ct = default)
+        {
+            var familyId = SessionInfo.GetFamilyId()
+                ?? throw new CalendarNoteRequiresFamilyException();
+            var userId = SessionInfo.GetUserId()
+                ?? throw new UnauthorizedAccessException("User not authenticated");
+
+            // Backstop behind ModelState: a missing DateOnly binds to 0001-01-01 rather than failing.
+            if (request.Date is not { } date || date == default)
+                throw new CalendarNoteInvalidDateException();
+
+            using var context = new HomassyDbContext();
+            var note = new CalendarNoteEntity
+            {
+                FamilyId = familyId,
+                Date = date,
+                Title = request.Title,
+                Content = NormalizeContent(request.Content),
+                CreatedByUserId = userId,
+                LastEditedByUserId = userId,
+                CreatedAt = DateTime.UtcNow,
+                RowVersion = Guid.NewGuid()
+            };
+
+            if (request.ReminderTime != null)
+            {
+                var timeOfDay = ParseReminderTime(request.ReminderTime);
+                var zone = ResolveUserTimeZone(userId);
+
+                note.ReminderTimeOfDay = timeOfDay;
+                note.ReminderTimeZone = zone;
+                note.ReminderAt = ComputeReminderAt(date, timeOfDay, zone);
+                StampIfAlreadyStale(note);
+            }
+
+            context.CalendarNotes.Add(note);
+            await context.SaveChangesAsync(ct);
+
+            var response = MapToResponse(note, new UserFunctions());
+
+            // Broadcast first (latency-sensitive), activity second (bookkeeping). The activity call has to come
+            // after SaveChangesAsync because it takes the internal int Id.
+            await MasterDataRealtime.CalendarNoteUpsertedAsync(familyId, response, ct);
+            await RecordActivitySafelyAsync(userId, familyId, ActivityType.CalendarNoteCreate, note.Id, note.Title, ct);
+
+            return response;
+        }
+
+        public async Task<CalendarNoteResponse> UpdateCalendarNoteAsync(
+            Guid publicId,
+            UpdateCalendarNoteRequest request,
+            CancellationToken ct = default)
+        {
+            var familyId = SessionInfo.GetFamilyId()
+                ?? throw new CalendarNoteRequiresFamilyException();
+            var userId = SessionInfo.GetUserId()
+                ?? throw new UnauthorizedAccessException("User not authenticated");
+
+            // Reject the contradictory combination before mutating anything.
+            if (request.ClearReminder && request.ReminderTime != null)
+                throw new CalendarNoteInvalidReminderException("Cannot set and clear the reminder in the same request.");
+
+            using var context = new HomassyDbContext();
+
+            // Fetch by PublicId only, then check the family — that keeps "does not exist" (404) distinguishable
+            // from "belongs to another family" (403).
+            var note = await context.CalendarNotes
+                .FirstOrDefaultAsync(n => n.PublicId == publicId, ct)
+                ?? throw new CalendarNoteNotFoundException();
+
+            if (note.FamilyId != familyId)
+                throw new CalendarNoteAccessDeniedException();
+
+            ApplyClientVersion(context, note, request.Version);
+
+            if (request.Title != null) note.Title = request.Title;
+            if (request.Content != null) note.Content = NormalizeContent(request.Content);
+
+            ApplyReminderPatch(note, request);
+
+            // Read this before stamping the editor fields — setting them would itself mark the entry Modified.
+            var hasChanges = context.ChangeTracker.HasChanges();
+
+            if (hasChanges)
+            {
+                note.LastEditedByUserId = userId;
+                note.LastEditedAt = DateTime.UtcNow;
+                note.RowVersion = Guid.NewGuid();
+            }
+
+            try
+            {
+                await context.SaveChangesAsync(ct);
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                throw new CalendarNoteConcurrencyException();
+            }
+
+            var response = MapToResponse(note, new UserFunctions());
+
+            // A no-op PUT must not spam the activity feed or the realtime channel.
+            if (hasChanges)
+            {
+                await MasterDataRealtime.CalendarNoteUpsertedAsync(familyId, response, ct);
+                await RecordActivitySafelyAsync(userId, familyId, ActivityType.CalendarNoteUpdate, note.Id, note.Title, ct);
+            }
+
+            return response;
+        }
+
+        public async Task DeleteCalendarNoteAsync(Guid publicId, CancellationToken ct = default)
+        {
+            var familyId = SessionInfo.GetFamilyId()
+                ?? throw new CalendarNoteRequiresFamilyException();
+            var userId = SessionInfo.GetUserId()
+                ?? throw new UnauthorizedAccessException("User not authenticated");
+
+            using var context = new HomassyDbContext();
+            var note = await context.CalendarNotes
+                .FirstOrDefaultAsync(n => n.PublicId == publicId, ct)
+                ?? throw new CalendarNoteNotFoundException();
+
+            if (note.FamilyId != familyId)
+                throw new CalendarNoteAccessDeniedException();
+
+            // The reminder fields are left intact: the global soft-delete filter already keeps the row out of
+            // the worker's scan, and leaving them coherent keeps a hypothetical undelete sane. LastEditedByUserId
+            // is likewise untouched — DeleteRecord overwrites RecordChange.LastModifiedBy with the deleter, which
+            // is precisely why the explicit author/editor columns exist.
+            note.DeleteRecord(userId);
+            await context.SaveChangesAsync(ct);
+
+            await MasterDataRealtime.CalendarNoteDeletedAsync(familyId, note.PublicId, ct);
+            await RecordActivitySafelyAsync(userId, familyId, ActivityType.CalendarNoteDelete, note.Id, note.Title, ct);
+        }
+
+        /// <summary>
+        /// Recomputes the reminder from the patch. The reminder is defined by the triple
+        /// (Date, ReminderTimeOfDay, ReminderTimeZone); <c>ReminderAt</c> is a derived projection, which is what
+        /// lets a date change be recomputed deterministically without guessing which zone to convert back through.
+        /// </summary>
+        private static void ApplyReminderPatch(CalendarNoteEntity note, UpdateCalendarNoteRequest request)
+        {
+            var newDate = request.Date ?? note.Date;
+
+            TimeOnly? newTimeOfDay;
+            if (request.ClearReminder)
+                newTimeOfDay = null;
+            else if (request.ReminderTime != null)
+                newTimeOfDay = ParseReminderTime(request.ReminderTime);
+            else
+                newTimeOfDay = note.ReminderTimeOfDay;
+
+            if (newTimeOfDay is null)
+            {
+                note.ReminderAt = null;
+                note.ReminderTimeOfDay = null;
+                note.ReminderTimeZone = null;
+                note.ReminderSentAt = null;
+            }
+            else
+            {
+                // The zone stays as first snapshotted, so neither an editor in another zone nor the author
+                // changing their profile timezone can silently move an existing reminder.
+                var zone = note.ReminderTimeZone ?? ResolveUserTimeZone(note.CreatedByUserId);
+                var newReminderAt = ComputeReminderAt(newDate, newTimeOfDay.Value, zone);
+
+                // Re-arm only when the instant actually moved AND moved into the future. Without the
+                // future-only half, nudging the time back and forth across "now" would clear ReminderSentAt
+                // repeatedly and re-push the same note.
+                if (newReminderAt != note.ReminderAt && newReminderAt > DateTime.UtcNow)
+                    note.ReminderSentAt = null;
+
+                note.ReminderAt = newReminderAt;
+                note.ReminderTimeOfDay = newTimeOfDay;
+                note.ReminderTimeZone = zone;
+                StampIfAlreadyStale(note);
+            }
+
+            note.Date = newDate;
+        }
+
+        /// <summary>
+        /// Seeds the row version the client read, so EF's concurrency check fires against that rather than
+        /// against the value this request just fetched. Without it the check would only cover the milliseconds
+        /// between fetch and save, which is not where a lost update happens.
+        /// </summary>
+        private static void ApplyClientVersion(HomassyDbContext context, CalendarNoteEntity note, string version)
+        {
+            if (!Guid.TryParse(version, out var parsed))
+                throw new CalendarNoteConcurrencyException("Malformed concurrency token");
+
+            context.Entry(note).Property(n => n.RowVersion).OriginalValue = parsed;
+        }
+
+        /// <summary>
+        /// Retires a reminder that can never be delivered — one whose instant is already older than the worker's
+        /// catch-up window (a note for today at 21:00 entered at 22:00, or a backfilled past note). Rejecting the
+        /// save instead would be user-hostile, and leaving it unclaimed would keep a row in the pending-reminder
+        /// index that the worker re-examines every minute forever.
+        /// </summary>
+        private static void StampIfAlreadyStale(CalendarNoteEntity note)
+        {
+            if (note.ReminderAt is { } at && at <= DateTime.UtcNow - ReminderCatchUpWindow)
+                note.ReminderSentAt = DateTime.UtcNow;
+        }
+
+        private static DateTime ComputeReminderAt(DateOnly date, TimeOnly timeOfDay, UserTimeZone zone) =>
+            zone.ToTimeZoneInfo().LocalToUtc(date.ToDateTime(timeOfDay));
+
+        private static TimeOnly ParseReminderTime(string value)
+        {
+            if (!TimeOnly.TryParse(value, CultureInfo.InvariantCulture, out var parsed))
+                throw new CalendarNoteInvalidReminderException("The reminder time must be given as HH:mm.");
+
+            return parsed;
+        }
+
+        private static UserTimeZone ResolveUserTimeZone(int userId) =>
+            new UserFunctions().GetUserProfileByUserId(userId)?.DefaultTimeZone
+                ?? UserTimeZone.CentralEuropeStandardTime;
+
+        /// <summary>Collapses an empty or whitespace body to null, so "no content" has one representation.</summary>
+        private static string? NormalizeContent(string? content) =>
+            string.IsNullOrWhiteSpace(content) ? null : content;
+
+        private static async Task RecordActivitySafelyAsync(
+            int userId, int familyId, ActivityType activityType, int recordId, string recordName, CancellationToken ct)
+        {
+            try
+            {
+                await new ActivityFunctions().RecordActivityAsync(
+                    userId, familyId, activityType, recordId, recordName, null, null, ct);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, $"Failed to record {activityType} activity for calendar note {recordId}");
+            }
+        }
+
+        private static CalendarNoteResponse MapToResponse(
+            CalendarNoteEntity note,
+            UserFunctions userFunctions)
+        {
+            var author = userFunctions.GetUserById(note.CreatedByUserId);
+            var lastEditor = note.LastEditedByUserId == note.CreatedByUserId
+                ? author
+                : userFunctions.GetUserById(note.LastEditedByUserId);
+
+            return new CalendarNoteResponse
+            {
+                PublicId = note.PublicId,
+                Date = note.Date,
+                Title = note.Title,
+                Content = note.Content,
+                ReminderAt = note.ReminderAt,
+                ReminderTime = note.ReminderTimeOfDay?.ToString(@"HH\:mm", CultureInfo.InvariantCulture),
+                ReminderTimeZone = note.ReminderTimeZone,
+                ReminderSentAt = note.ReminderSentAt,
+                AuthorPublicId = author?.PublicId ?? Guid.Empty,
+                AuthorName = ResolveDisplayName(note.CreatedByUserId, author, userFunctions),
+                LastEditedByPublicId = lastEditor?.PublicId ?? Guid.Empty,
+                LastEditedByName = ResolveDisplayName(note.LastEditedByUserId, lastEditor, userFunctions),
+                CreatedAt = note.CreatedAt,
+                LastEditedAt = note.LastEditedAt,
+                Version = note.RowVersion.ToString()
+            };
+        }
+
+        /// <summary>
+        /// Profile display name first, account name second — both come out of <see cref="UserFunctions"/>'
+        /// caches, so resolving a whole range costs no extra queries. A member who has since left the family
+        /// still resolves, which is correct: the note is history.
+        /// </summary>
+        private static string ResolveDisplayName(int userId, Entities.User.User? user, UserFunctions userFunctions) =>
+            userFunctions.GetUserProfileByUserId(userId)?.DisplayName
+                ?? user?.Name
+                ?? "Unknown User";
+    }
+}

--- a/Homassy.API/Hubs/MasterDataRealtime.cs
+++ b/Homassy.API/Hubs/MasterDataRealtime.cs
@@ -1,5 +1,6 @@
 using Homassy.API.Infrastructure;
 using Homassy.API.Models.Automation;
+using Homassy.API.Models.CalendarNote;
 using Homassy.API.Models.ExternalCalendar;
 using Homassy.API.Models.Location;
 using Homassy.API.Models.Product;
@@ -24,6 +25,7 @@ namespace Homassy.API.Hubs
     /// <item>Automations have mutually-exclusive <c>UserId</c>/<c>FamilyId</c> (plus a always-set
     /// <c>CreatedByUserId</c> fallback): family group when family-shared, else the owner's user group.</item>
     /// <item>External calendars are always family-scoped: family group only.</item>
+    /// <item>Calendar notes are always family-scoped: family group only.</item>
     /// </list>
     /// </summary>
     public static class MasterDataRealtime
@@ -38,6 +40,8 @@ namespace Homassy.API.Hubs
         public const string AutomationDeletedEvent = "AutomationDeleted";
         public const string ExternalCalendarUpsertedEvent = "ExternalCalendarUpserted";
         public const string ExternalCalendarDeletedEvent = "ExternalCalendarDeleted";
+        public const string CalendarNoteUpsertedEvent = "CalendarNoteUpserted";
+        public const string CalendarNoteDeletedEvent = "CalendarNoteDeleted";
 
         /// <summary>SignalR group for a family's shared master data. Shared with <see cref="MasterDataHub"/>.</summary>
         public static string FamilyGroup(int familyId) => $"masterdata:family:{familyId}";
@@ -91,6 +95,13 @@ namespace Homassy.API.Hubs
 
         public static Task ExternalCalendarDeletedAsync(int familyId, Guid publicId, CancellationToken cancellationToken = default)
             => SendAsync(FamilyGroup(familyId), ExternalCalendarDeletedEvent, new { publicId }, cancellationToken);
+
+        // --- Calendar notes (always family-scoped) ------------------------------
+        public static Task CalendarNoteUpsertedAsync(int familyId, CalendarNoteResponse note, CancellationToken cancellationToken = default)
+            => SendAsync(FamilyGroup(familyId), CalendarNoteUpsertedEvent, note, cancellationToken);
+
+        public static Task CalendarNoteDeletedAsync(int familyId, Guid publicId, CancellationToken cancellationToken = default)
+            => SendAsync(FamilyGroup(familyId), CalendarNoteDeletedEvent, new { publicId }, cancellationToken);
 
         private static async Task SendAsync(string group, string eventName, object payload, CancellationToken cancellationToken)
         {

--- a/Homassy.API/Middleware/GlobalExceptionMiddleware.cs
+++ b/Homassy.API/Middleware/GlobalExceptionMiddleware.cs
@@ -96,6 +96,14 @@ namespace Homassy.API.Middleware
                 ExternalCalendarFetchFailedException ex => (StatusCodes.Status400BadRequest, ex.ErrorCode),
                 ExternalCalendarRequiresFamilyException ex => (StatusCodes.Status400BadRequest, ex.ErrorCode),
 
+                // Calendar note exceptions
+                CalendarNoteNotFoundException ex => (StatusCodes.Status404NotFound, ex.ErrorCode),
+                CalendarNoteAccessDeniedException ex => (StatusCodes.Status403Forbidden, ex.ErrorCode),
+                CalendarNoteRequiresFamilyException ex => (StatusCodes.Status400BadRequest, ex.ErrorCode),
+                CalendarNoteInvalidDateException ex => (StatusCodes.Status400BadRequest, ex.ErrorCode),
+                CalendarNoteInvalidReminderException ex => (StatusCodes.Status400BadRequest, ex.ErrorCode),
+                CalendarNoteConcurrencyException ex => (StatusCodes.Status409Conflict, ex.ErrorCode),
+
                 // Timeout exceptions
                 RequestTimeoutException ex => (StatusCodes.Status504GatewayTimeout, ex.ErrorCode),
 

--- a/Homassy.API/Migrations/20260729174318_AddCalendarNotes.Designer.cs
+++ b/Homassy.API/Migrations/20260729174318_AddCalendarNotes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Homassy.API.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Homassy.API.Migrations
 {
     [DbContext(typeof(HomassyDbContext))]
-    partial class HomassyDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260729174318_AddCalendarNotes")]
+    partial class AddCalendarNotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Homassy.API/Migrations/20260729174318_AddCalendarNotes.cs
+++ b/Homassy.API/Migrations/20260729174318_AddCalendarNotes.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Homassy.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCalendarNotes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CalendarNotes",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    FamilyId = table.Column<int>(type: "integer", nullable: false),
+                    Date = table.Column<DateOnly>(type: "date", nullable: false),
+                    Title = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Content = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    ReminderTimeOfDay = table.Column<TimeOnly>(type: "time without time zone", nullable: true),
+                    ReminderTimeZone = table.Column<int>(type: "integer", nullable: true),
+                    ReminderAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    ReminderSentAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedByUserId = table.Column<int>(type: "integer", nullable: false),
+                    LastEditedByUserId = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    LastEditedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    RowVersion = table.Column<Guid>(type: "uuid", nullable: false),
+                    PublicId = table.Column<Guid>(type: "uuid", nullable: false, defaultValueSql: "gen_random_uuid()"),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    RecordChange = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CalendarNotes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CalendarNotes_Families_FamilyId",
+                        column: x => x.FamilyId,
+                        principalTable: "Families",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CalendarNotes_Users_CreatedByUserId",
+                        column: x => x.CreatedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_CalendarNotes_Users_LastEditedByUserId",
+                        column: x => x.LastEditedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CalendarNotes_CreatedByUserId",
+                table: "CalendarNotes",
+                column: "CreatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CalendarNotes_FamilyId_Date",
+                table: "CalendarNotes",
+                columns: new[] { "FamilyId", "Date" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CalendarNotes_LastEditedByUserId",
+                table: "CalendarNotes",
+                column: "LastEditedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CalendarNotes_PendingReminder",
+                table: "CalendarNotes",
+                column: "ReminderAt",
+                filter: "\"ReminderAt\" IS NOT NULL AND \"ReminderSentAt\" IS NULL AND \"IsDeleted\" = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CalendarNotes");
+        }
+    }
+}

--- a/Homassy.API/Models/CalendarNote/CalendarNoteResponse.cs
+++ b/Homassy.API/Models/CalendarNote/CalendarNoteResponse.cs
@@ -1,0 +1,40 @@
+using Homassy.API.Enums;
+
+namespace Homassy.API.Models.CalendarNote
+{
+    public class CalendarNoteResponse
+    {
+        public Guid PublicId { get; set; }
+        public DateOnly Date { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string? Content { get; set; }
+
+        /// <summary>Absolute instant the reminder fires, or null when there is none.</summary>
+        public DateTime? ReminderAt { get; set; }
+
+        /// <summary>
+        /// The wall-clock time the author picked, as <c>HH:mm</c>. Exposed alongside <see cref="ReminderAt"/>
+        /// because a member in another zone rendering the instant locally would see a *different* time than the
+        /// author chose — which reads as a bug unless the intent is available too.
+        /// </summary>
+        public string? ReminderTime { get; set; }
+
+        /// <summary>The zone <see cref="ReminderTime"/> is anchored in, so the UI can qualify it.</summary>
+        public UserTimeZone? ReminderTimeZone { get; set; }
+
+        public DateTime? ReminderSentAt { get; set; }
+
+        public Guid AuthorPublicId { get; set; }
+        public string AuthorName { get; set; } = string.Empty;
+        public Guid LastEditedByPublicId { get; set; }
+        public string LastEditedByName { get; set; } = string.Empty;
+
+        public DateTime CreatedAt { get; set; }
+
+        /// <summary>Null until the note is actually edited.</summary>
+        public DateTime? LastEditedAt { get; set; }
+
+        /// <summary>Opaque concurrency token; echo it back on update.</summary>
+        public string Version { get; set; } = string.Empty;
+    }
+}

--- a/Homassy.API/Models/CalendarNote/CreateCalendarNoteRequest.cs
+++ b/Homassy.API/Models/CalendarNote/CreateCalendarNoteRequest.cs
@@ -1,0 +1,30 @@
+using Homassy.API.Attributes.Validation;
+using System.ComponentModel.DataAnnotations;
+
+namespace Homassy.API.Models.CalendarNote
+{
+    public class CreateCalendarNoteRequest
+    {
+        /// <summary>The day the note is about. Nullable so <c>[Required]</c> actually bites (see the range request).</summary>
+        [Required]
+        public DateOnly? Date { get; set; }
+
+        [Required]
+        [StringLength(128, MinimumLength = 1)]
+        [SanitizedString]
+        public required string Title { get; set; }
+
+        [StringLength(2000)]
+        [SafeFreeText]
+        public string? Content { get; set; }
+
+        /// <summary>
+        /// Reminder time of day as <c>HH:mm</c>, interpreted in the author's profile timezone. Null = no reminder.
+        /// A wall-clock string rather than a client-computed instant: the browser's device timezone is not
+        /// necessarily the author's configured one, and a client instant could also be set unrelated to
+        /// <see cref="Date"/>. The server owns the conversion.
+        /// </summary>
+        [StringLength(8)]
+        public string? ReminderTime { get; set; }
+    }
+}

--- a/Homassy.API/Models/CalendarNote/GetCalendarNotesRequest.cs
+++ b/Homassy.API/Models/CalendarNote/GetCalendarNotesRequest.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Homassy.API.Models.CalendarNote
+{
+    public class GetCalendarNotesRequest
+    {
+        /// <summary>
+        /// Nullable on purpose: <c>[Required]</c> on a non-nullable struct is a no-op, so a missing field would
+        /// bind to <c>0001-01-01</c> and sail through <c>ModelState</c>.
+        /// </summary>
+        [Required]
+        public DateOnly? StartDate { get; set; }
+
+        [Required]
+        public DateOnly? EndDate { get; set; }
+    }
+}

--- a/Homassy.API/Models/CalendarNote/UpdateCalendarNoteRequest.cs
+++ b/Homassy.API/Models/CalendarNote/UpdateCalendarNoteRequest.cs
@@ -1,0 +1,44 @@
+using Homassy.API.Attributes.Validation;
+using System.ComponentModel.DataAnnotations;
+
+namespace Homassy.API.Models.CalendarNote
+{
+    /// <summary>
+    /// Partial patch: a null property leaves that field unchanged.
+    /// </summary>
+    public class UpdateCalendarNoteRequest
+    {
+        public DateOnly? Date { get; set; }
+
+        [StringLength(128, MinimumLength = 1)]
+        [SanitizedString]
+        public string? Title { get; set; }
+
+        /// <summary>
+        /// Null leaves the body unchanged; an empty or whitespace string erases it. A string has an unambiguous
+        /// empty value, so it needs no companion flag the way the reminder does.
+        /// </summary>
+        [StringLength(2000)]
+        [SafeFreeText]
+        public string? Content { get; set; }
+
+        /// <summary>Null leaves the reminder unchanged. Use <see cref="ClearReminder"/> to remove it.</summary>
+        [StringLength(8)]
+        public string? ReminderTime { get; set; }
+
+        /// <summary>
+        /// Removes the reminder. Needed because a null <see cref="ReminderTime"/> already means "no change", and
+        /// <c>""</c> cannot stand in for "none" here — it would reach the time parser as an accidental 400.
+        /// Sending this together with a non-null <see cref="ReminderTime"/> is rejected, not silently resolved.
+        /// </summary>
+        public bool ClearReminder { get; set; }
+
+        /// <summary>
+        /// The concurrency token the client read with the note. Compared against the row's current version so a
+        /// stale form cannot silently overwrite another member's edit; a mismatch is a 409.
+        /// </summary>
+        [Required]
+        [StringLength(64)]
+        public required string Version { get; set; }
+    }
+}

--- a/Homassy.API/Services/CacheManagementService.cs
+++ b/Homassy.API/Services/CacheManagementService.cs
@@ -321,6 +321,11 @@ namespace Homassy.API.Services
                     Log.Debug("FamilyExternalCalendars change recorded (id: {RecordId})", change.RecordId);
                     break;
 
+                case TableNames.CalendarNotes:
+                    // No in-memory cache for calendar notes; data read directly from DB.
+                    Log.Debug("CalendarNotes change recorded (id: {RecordId})", change.RecordId);
+                    break;
+
                 default:
                     Log.Warning($"Unknown table name in TableRecordChanges: {change.TableName}");
                     break;

--- a/Homassy.Notifications/CLAUDE.md
+++ b/Homassy.Notifications/CLAUDE.md
@@ -79,6 +79,7 @@ Homassy.Notifications/
     ├── InventoryActivityMonitorService.cs     # 5 min → inventory (készlet) push
     ├── FamilyJoinRequestMonitorService.cs     # 1 min → family join request push
     ├── ItemAutomationWorkerService.cs         # 5 min → item automation execution
+    ├── CalendarNoteReminderService.cs         # 1 min → day note reminders
     └── EmailWeeklySummaryService.cs           # Hourly, Mon 07:00 → weekly email
 ```
 
@@ -164,6 +165,27 @@ builder.Services.AddDbContext<HomassyDbContext>(options =>
 - After an `AutoConsume` commit it relays the inventory change to `Homassy.API` via
   `InventoryBroadcastServiceClient` (→ `POST /api/v1/internal/inventory/broadcast`) so connected
   Készletek grids update live; this process hosts no SignalR hub, so it cannot broadcast directly
+
+### CalendarNoteReminderService
+- Runs every minute: a day-note reminder is a wall-clock promise ("08:00"), and a 5-minute loop would turn that
+  into "08:00–08:05"
+- Scans `CalendarNotes` for a due `ReminderAt` (derived API-side from the note's date and the **author's**
+  timezone, so every family member is notified at the same instant). The query matches the
+  `IX_CalendarNotes_PendingReminder` partial index, so it only ever touches pending reminders
+- Notifies every family member with push enabled via `FamilyPushNotifier`, **including the author** — they set
+  the reminder for themselves as much as for anyone. This differs from the activity monitors, which exclude the
+  actor because they report someone else's action
+- **Claim-then-push**: a single conditional `ExecuteUpdateAsync`
+  (`SET ReminderSentAt = now WHERE Id = @id AND ReminderSentAt IS NULL`) is committed *before* the push, so a
+  crash, a restart inside the catch-up window, or two replicas racing can only skip a send — never repeat one.
+  Never restructure this into read-then-push-then-save
+- `ExecuteUpdateAsync` also avoids `SaveChangesAsync`, which would stamp `RecordChange.LastModifiedBy = -1`
+  (this process has no `SessionInfoMiddleware`), and it respects the global soft-delete filter, so a deleted note
+  can never be pushed
+- 15-minute catch-up window (shared with `CalendarNoteFunctions.ReminderCatchUpWindow` so the write-time
+  staleness check cannot diverge); anything older is dropped as stale. A 6-hourly sweep retires reminders left
+  unclaimed past a day, which is what keeps the partial index bounded across an outage — there is no marker
+  table to prune, the dedup state lives on the note row
 
 ### EmailWeeklySummaryService
 - Runs every hour

--- a/Homassy.Notifications/Program.cs
+++ b/Homassy.Notifications/Program.cs
@@ -44,6 +44,7 @@ try
     builder.Services.AddHostedService<FamilyJoinRequestMonitorService>();
     builder.Services.AddHostedService<EmailWeeklySummaryService>();
     builder.Services.AddHostedService<ItemAutomationWorkerService>();
+    builder.Services.AddHostedService<CalendarNoteReminderService>();
 
     // Health checks
     builder.Services.AddHealthChecks()

--- a/Homassy.Notifications/Services/PushNotificationContentService.cs
+++ b/Homassy.Notifications/Services/PushNotificationContentService.cs
@@ -1,4 +1,5 @@
 ﻿using Homassy.API.Enums;
+using System.Globalization;
 
 namespace Homassy.Notifications.Services;
 
@@ -425,5 +426,59 @@ public static class PushNotificationContentService
                 $"Your request to join the \"{familyName}\" family was declined."
             )
         };
+    }
+
+    /// <summary>
+    /// Reminder for a family day note.
+    /// <para>
+    /// The note's date is stated absolutely rather than relatively ("tomorrow") because
+    /// <c>FamilyPushNotifier.DispatchAsync</c> hands the content factory only the recipient's language — not
+    /// their timezone — so a relative phrase could be wrong for a member in another zone. The date pattern is
+    /// explicit and invariant so the container's locale cannot change the output.
+    /// </para>
+    /// </summary>
+    public static (string Title, string Body) GetCalendarNoteReminderContent(
+        Language language, string noteTitle, string? noteContent, DateOnly noteDate)
+    {
+        var snippet = Snippet(noteContent);
+
+        return language switch
+        {
+            Language.Hungarian => (
+                "Napi jegyzet",
+                Compose(noteDate.ToString("yyyy. MM. dd.", CultureInfo.InvariantCulture), noteTitle, snippet)
+            ),
+            Language.German => (
+                "Tagesnotiz",
+                Compose(noteDate.ToString("dd.MM.yyyy", CultureInfo.InvariantCulture), noteTitle, snippet)
+            ),
+            _ => (
+                "Day note",
+                Compose(noteDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture), noteTitle, snippet)
+            )
+        };
+    }
+
+    private static string Compose(string dateText, string noteTitle, string? snippet) =>
+        snippet == null
+            ? $"{dateText} · {noteTitle}"
+            : $"{dateText} · {noteTitle} — {snippet}";
+
+    /// <summary>
+    /// Trims a note body down to something a notification can carry — payloads are size-limited and visually
+    /// truncated anyway, so a 2000-character body must not ride along in full.
+    /// </summary>
+    private static string? Snippet(string? content, int maxLength = 120)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return null;
+
+        // Newlines would be rendered as spaces by the notification surface anyway; collapse them so the
+        // truncation length reflects what is actually shown.
+        var flattened = string.Join(' ', content.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+        return flattened.Length <= maxLength
+            ? flattened
+            : string.Concat(flattened.AsSpan(0, maxLength).TrimEnd(), "…");
     }
 }

--- a/Homassy.Notifications/Workers/CalendarNoteReminderService.cs
+++ b/Homassy.Notifications/Workers/CalendarNoteReminderService.cs
@@ -1,0 +1,199 @@
+using Homassy.API.Context;
+using Homassy.API.Functions;
+using Homassy.Notifications.Services;
+using Microsoft.EntityFrameworkCore;
+using Serilog;
+
+namespace Homassy.Notifications.Workers;
+
+/// <summary>
+/// Pushes the reminder attached to a family day note. The reminder is one absolute instant
+/// (<c>CalendarNote.ReminderAt</c>, derived API-side from the note's date and the author's timezone), so every
+/// member of the family is notified at the same moment.
+/// <para>
+/// Polls every minute rather than every five: a note reminder is a wall-clock promise ("08:00"), and a
+/// five-minute loop would turn that into "08:00–08:05".
+/// </para>
+/// <para>
+/// Duplicate suppression is a claim-then-push. The claim is a single conditional UPDATE
+/// (<c>SET ReminderSentAt = now WHERE Id = @id AND ReminderSentAt IS NULL</c>) committed <em>before</em> the
+/// push goes out, so a crash, a restart inside the catch-up window, or two replicas racing can only ever skip a
+/// send — never repeat one. Never restructure this into read-then-push-then-save.
+/// </para>
+/// </summary>
+public sealed class CalendarNoteReminderService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly FamilyPushNotifier _notifier;
+
+    private readonly TimeSpan _interval = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// A reminder whose instant has already passed is still delivered inside this window, so a deploy or a
+    /// short outage does not silently swallow it. Anything older is dropped as stale — a "today" reminder
+    /// arriving hours late is worse than not arriving. Shared with <see cref="CalendarNoteFunctions"/> so the
+    /// write-time staleness check and this delivery window cannot diverge.
+    /// </summary>
+    private static readonly TimeSpan CatchUpWindow = CalendarNoteFunctions.ReminderCatchUpWindow;
+
+    /// <summary>Per-cycle cap. At one cycle a minute this still clears 3000 notes inside the catch-up window.</summary>
+    private const int MaxNotesPerCycle = 200;
+
+    /// <summary>
+    /// A reminder left unclaimed this long can never be delivered (the service was down past the catch-up
+    /// window), so it is retired to keep the pending-reminder index from growing without bound.
+    /// </summary>
+    private static readonly TimeSpan StaleRetirementAge = TimeSpan.FromDays(1);
+    private static readonly TimeSpan SweepInterval = TimeSpan.FromHours(6);
+    private DateTime _nextSweepUtc = DateTime.MinValue;
+
+    public CalendarNoteReminderService(IServiceScopeFactory scopeFactory, FamilyPushNotifier notifier)
+    {
+        _scopeFactory = scopeFactory;
+        _notifier = notifier;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        Log.Information("Calendar note reminder service started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(_interval, stoppingToken);
+                await ProcessAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error in calendar note reminder service");
+                try { await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken); }
+                catch (OperationCanceledException) { break; }
+            }
+        }
+
+        Log.Information("Calendar note reminder service stopped");
+    }
+
+    private async Task ProcessAsync(CancellationToken cancellationToken)
+    {
+        var nowUtc = DateTime.UtcNow;
+        var windowStart = nowUtc - CatchUpWindow;
+
+        using var scope = _scopeFactory.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<HomassyDbContext>();
+
+        // Matches the IX_CalendarNotes_PendingReminder partial index (plus IsDeleted = false from the global
+        // query filter), so this is an index scan over pending reminders only. Ordering by ReminderAt — not Id —
+        // is what keeps families fair under MaxNotesPerCycle; don't change it.
+        var due = await context.CalendarNotes
+            .AsNoTracking()
+            .Where(n => n.ReminderAt != null
+                     && n.ReminderSentAt == null
+                     && n.ReminderAt <= nowUtc
+                     && n.ReminderAt > windowStart)
+            .OrderBy(n => n.ReminderAt)
+            .Take(MaxNotesPerCycle)
+            .Select(n => new DueNote(n.Id, n.PublicId, n.FamilyId, n.Title, n.Content, n.Date))
+            .ToListAsync(cancellationToken);
+
+        // Grouped by family so recipients are resolved once per family per cycle — several notes easily come
+        // due at the same 08:00.
+        foreach (var family in due.GroupBy(n => n.FamilyId))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return;
+
+            try
+            {
+                await ProcessFamilyAsync(context, family.Key, family.ToList(), nowUtc, cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error sending calendar note reminders for family {FamilyId}", family.Key);
+            }
+        }
+
+        await RetireStaleRemindersAsync(context, nowUtc, cancellationToken);
+    }
+
+    private async Task ProcessFamilyAsync(
+        HomassyDbContext context,
+        int familyId,
+        List<DueNote> notes,
+        DateTime nowUtc,
+        CancellationToken cancellationToken)
+    {
+        // Empty exclude list: the author is notified too. They set the reminder for themselves as much as for
+        // anyone, which is why this differs from the activity monitors (those report someone else's action).
+        var recipients = await _notifier.GetRecipientsAsync(context, familyId, [], cancellationToken);
+
+        if (recipients.Count == 0)
+        {
+            // Deliberately not claimed: stamping a false "sent" for a family with push disabled would also mean
+            // that enabling push a minute later misses a reminder that is still inside the catch-up window.
+            Log.Debug("Family {FamilyId} has {Count} due calendar note reminder(s) but no push recipients",
+                familyId, notes.Count);
+            return;
+        }
+
+        foreach (var note in notes)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                return;
+
+            var claimed = await context.CalendarNotes
+                .Where(n => n.Id == note.Id && n.ReminderSentAt == null)
+                .ExecuteUpdateAsync(s => s.SetProperty(n => n.ReminderSentAt, nowUtc), cancellationToken);
+
+            if (claimed == 0)
+            {
+                Log.Debug("Calendar note {NotePublicId} reminder was already claimed elsewhere", note.PublicId);
+                continue;
+            }
+
+            await _notifier.DispatchAsync(context, recipients,
+                language =>
+                [
+                    PushNotificationContentService.GetCalendarNoteReminderContent(
+                        language, note.Title, note.Content, note.Date)
+                ],
+                "/calendar", cancellationToken);
+
+            Log.Information(
+                "Calendar note reminder sent to {Count} member(s) of family {FamilyId} for note {NotePublicId}",
+                recipients.Count, familyId, note.PublicId);
+        }
+    }
+
+    /// <summary>
+    /// Retires reminders that fell out of the catch-up window while the service was down. There is no marker
+    /// table to prune — the dedup state lives on the note row and dies with it — but an unclaimed past reminder
+    /// would otherwise sit in the pending-reminder index forever, re-examined every minute.
+    /// </summary>
+    private async Task RetireStaleRemindersAsync(HomassyDbContext context, DateTime nowUtc, CancellationToken cancellationToken)
+    {
+        if (nowUtc < _nextSweepUtc)
+            return;
+
+        _nextSweepUtc = nowUtc + SweepInterval;
+        var cutoff = nowUtc - StaleRetirementAge;
+
+        var retired = await context.CalendarNotes
+            .Where(n => n.ReminderAt != null && n.ReminderSentAt == null && n.ReminderAt < cutoff)
+            .ExecuteUpdateAsync(s => s.SetProperty(n => n.ReminderSentAt, nowUtc), cancellationToken);
+
+        if (retired > 0)
+            Log.Information("Retired {Count} undeliverable calendar note reminder(s)", retired);
+    }
+
+    private sealed record DueNote(int Id, Guid PublicId, int FamilyId, string Title, string? Content, DateOnly Date);
+}

--- a/Homassy.Web/app/components/CalendarNoteFormDrawer.vue
+++ b/Homassy.Web/app/components/CalendarNoteFormDrawer.vue
@@ -1,0 +1,228 @@
+<template>
+  <AppDrawer
+    :open="open"
+    :title="title"
+    icon="i-lucide-notebook-pen"
+    :loading="saving"
+    @update:open="(v) => emit('update:open', v)"
+  >
+    <UForm ref="formRef" :schema="schema" :state="form" class="space-y-4" @submit="onSubmit">
+      <UFormField :label="t('pages.calendar.dayNotes.date')" name="date" required>
+        <UInputDate v-model="datePicker" :locale="inputDateLocale" :disabled="saving" class="w-full">
+          <template #trailing>
+            <UPopover>
+              <UButton icon="i-lucide-calendar" color="neutral" variant="ghost" size="xs" :disabled="saving" />
+              <template #content>
+                <UCalendar v-model="datePicker" :locale="inputDateLocale" />
+              </template>
+            </UPopover>
+          </template>
+        </UInputDate>
+      </UFormField>
+
+      <UFormField :label="t('pages.calendar.dayNotes.noteTitle')" name="title" required>
+        <UInput
+          v-model="form.title"
+          :placeholder="t('pages.calendar.dayNotes.titlePlaceholder')"
+          :disabled="saving"
+          class="w-full"
+        />
+      </UFormField>
+
+      <UFormField :label="t('pages.calendar.dayNotes.content')" name="content">
+        <UTextarea
+          v-model="form.content"
+          :placeholder="t('pages.calendar.dayNotes.contentPlaceholder')"
+          :rows="5"
+          :disabled="saving"
+          class="w-full"
+        />
+      </UFormField>
+
+      <UFormField name="reminderEnabled">
+        <UCheckbox
+          v-model="form.reminderEnabled"
+          :label="t('pages.calendar.dayNotes.reminderEnabled')"
+          :disabled="saving"
+        />
+      </UFormField>
+
+      <!-- Only shown once the reminder is on: an empty time input beside an off checkbox reads as broken. -->
+      <UFormField v-if="form.reminderEnabled" :label="t('pages.calendar.dayNotes.reminderTime')" name="reminderTime">
+        <UInput v-model="form.reminderTime" type="time" :disabled="saving" class="w-32" />
+        <p class="text-xs text-muted mt-1">{{ t('pages.calendar.dayNotes.reminderHint') }}</p>
+      </UFormField>
+    </UForm>
+
+    <template #footer>
+      <UButton :label="t('common.cancel')" color="neutral" variant="ghost" @click="emit('update:open', false)" />
+      <UButton
+        :label="t('common.save')"
+        color="primary"
+        icon="i-lucide-save"
+        :loading="saving"
+        @click="formRef?.submit()"
+      />
+    </template>
+  </AppDrawer>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { z } from 'zod'
+import type { CalendarDate } from '@internationalized/date'
+import { CalendarDate as CalendarDateClass } from '@internationalized/date'
+import type { FormSubmitEvent } from '@nuxt/ui'
+import { useCalendarNoteApi } from '~/composables/api/useCalendarNoteApi'
+import type { CalendarNoteResponse } from '~/types/calendarNote'
+
+/**
+ * Create/edit a family day note. Owns the API call and emits `saved` with the resulting DTO so the calendar can
+ * patch locally; the master-data socket delivers the same change to other members.
+ */
+const props = withDefaults(defineProps<{
+  open: boolean
+  note?: CalendarNoteResponse | null
+  /** `YYYY-MM-DD` seed for a new note — normally the day selected on the calendar. */
+  date: string
+}>(), {
+  note: null
+})
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+  saved: [note: CalendarNoteResponse]
+  /** Another member changed the note first; the page should reload rather than retry. */
+  conflict: []
+}>()
+
+const { t } = useI18n()
+const toast = useToast()
+const { inputDateLocale } = useInputDateLocale()
+const { createCalendarNote, updateCalendarNote } = useCalendarNoteApi()
+
+const isEdit = computed(() => !!props.note)
+const title = computed(() => isEdit.value
+  ? t('pages.calendar.dayNotes.edit')
+  : t('pages.calendar.dayNotes.create'))
+
+const schema = z.object({
+  // A plain `YYYY-MM-DD` string rather than a CalendarDate: the picker's class type does not survive a `ref`
+  // deep-unwrap or a Zod inference round-trip, and the string is already the shape the API wants.
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, t('pages.calendar.dayNotes.dateRequired')),
+  title: z.string({ required_error: t('pages.calendar.dayNotes.titleRequired') })
+    .min(1, t('pages.calendar.dayNotes.titleRequired'))
+    .max(128),
+  content: z.string().max(2000).optional(),
+  reminderEnabled: z.boolean().optional().default(false),
+  reminderTime: z.string()
+    .regex(NOTE_REMINDER_TIME_PATTERN, t('pages.calendar.dayNotes.invalidTime'))
+    .optional()
+    .or(z.literal(''))
+}).refine(d => !d.reminderEnabled || !!d.reminderTime, {
+  path: ['reminderTime'],
+  message: t('pages.calendar.dayNotes.invalidTime')
+})
+type Schema = z.output<typeof schema>
+
+// `YYYY-MM-DD` <-> CalendarDate, never via Date/toISOString() which would shift the day off UTC.
+const toCalendarDate = (key: string): CalendarDate => {
+  const [y, m, d] = noteDayKey(key).split('-').map(Number)
+  return new CalendarDateClass(y ?? 1970, m ?? 1, d ?? 1)
+}
+
+const emptyForm = (dateKey: string) => ({
+  date: noteDayKey(dateKey),
+  title: '',
+  content: '',
+  reminderEnabled: false,
+  reminderTime: DEFAULT_NOTE_REMINDER_TIME
+})
+
+const form = ref(emptyForm(props.date))
+const saving = ref(false)
+const formRef = ref()
+
+/** Bridges the pickers (which speak `CalendarDate`) to the string the form state holds. */
+const datePicker = computed<CalendarDate>({
+  get: () => toCalendarDate(form.value.date),
+  set: (value) => {
+    if (value) form.value.date = toDateKey(value.year, value.month, value.day)
+  }
+})
+
+// Hydrate on open, not on prop change: the parent keeps `note` set while the drawer animates closed.
+watch(() => props.open, (isOpen) => {
+  if (!isOpen) return
+  if (props.note) {
+    form.value = {
+      date: noteDayKey(props.note.date),
+      title: props.note.title,
+      content: props.note.content || '',
+      reminderEnabled: !!props.note.reminderTime,
+      reminderTime: props.note.reminderTime || DEFAULT_NOTE_REMINDER_TIME
+    }
+  } else {
+    form.value = emptyForm(props.date)
+  }
+})
+
+async function onSubmit(event: FormSubmitEvent<Schema>) {
+  const data = event.data
+  saving.value = true
+  try {
+    const dateKey = data.date
+    const reminderTime = data.reminderEnabled ? (data.reminderTime || null) : null
+
+    const res = props.note
+      ? await updateCalendarNote(props.note.publicId, {
+        date: dateKey,
+        title: data.title.trim(),
+        // '' erases the body; omitting the key would mean "unchanged", so always send a value.
+        content: data.content?.trim() ?? '',
+        // An omitted key reads as "unchanged" server-side, which would make the reminder impossible to
+        // remove — the explicit flag is what clears it.
+        reminderTime: reminderTime ?? undefined,
+        clearReminder: reminderTime === null,
+        version: props.note.version
+      })
+      : await createCalendarNote({
+        date: dateKey,
+        title: data.title.trim(),
+        content: data.content?.trim() || null,
+        reminderTime
+      })
+
+    if (res.success && res.data) {
+      emit('saved', res.data)
+      emit('update:open', false)
+      return
+    }
+
+    // useApiClient has already toasted the translated code; a conflict additionally needs a reload, because
+    // retrying with the same stale version would fail again.
+    if (res.errorCodes?.includes('CALNOTE-0006')) {
+      emit('conflict')
+      emit('update:open', false)
+      return
+    }
+
+    toast.add({
+      title: t('common.error'),
+      description: t('pages.calendar.dayNotes.saveFailed'),
+      color: 'error',
+      icon: 'i-lucide-alert-circle'
+    })
+  } catch (error) {
+    console.error('Failed to save calendar note:', error)
+    toast.add({
+      title: t('common.error'),
+      description: t('pages.calendar.dayNotes.saveFailed'),
+      color: 'error',
+      icon: 'i-lucide-alert-circle'
+    })
+  } finally {
+    saving.value = false
+  }
+}
+</script>

--- a/Homassy.Web/app/components/calendar/CalendarNoteCard.vue
+++ b/Homassy.Web/app/components/calendar/CalendarNoteCard.vue
@@ -1,0 +1,139 @@
+<template>
+  <div class="relative rounded-xl overflow-hidden" style="touch-action: pan-y" data-no-pull-refresh>
+    <!-- Swipe action layer -->
+    <div
+      v-show="swipe.isSwiping.value"
+      aria-hidden="true"
+      class="absolute inset-0 rounded-xl flex items-center justify-between px-4"
+      :class="swipe.direction.value === 'left' ? 'bg-error-500 dark:bg-error-600' : 'bg-primary-500 dark:bg-primary-600'"
+    >
+      <UIcon
+        name="i-lucide-pencil"
+        class="h-5 w-5 text-white transition-transform duration-150"
+        :class="[swipe.direction.value === 'right' ? 'opacity-100' : 'opacity-0', swipe.progress.value >= 1 ? 'scale-125' : '']"
+      />
+      <UIcon
+        name="i-lucide-trash-2"
+        class="h-5 w-5 text-white transition-transform duration-150"
+        :class="[swipe.direction.value === 'left' ? 'opacity-100' : 'opacity-0', swipe.progress.value >= 1 ? 'scale-125' : '']"
+      />
+    </div>
+
+    <!-- Card surface -->
+    <div
+      ref="cardEl"
+      class="relative rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-3 border-l-4 border-l-emerald-500 cursor-pointer select-none"
+      :style="swipe.cardStyle.value"
+      @click="handleCardClick"
+    >
+      <div class="flex items-start justify-between gap-2">
+        <span class="text-sm font-medium text-gray-900 dark:text-gray-100 leading-snug">
+          {{ note.title }}
+        </span>
+        <div class="flex items-center gap-1 shrink-0">
+          <span class="text-xs rounded px-1.5 py-0.5 leading-tight bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
+            {{ t('pages.calendar.eventTypes.dayNote') }}
+          </span>
+          <!-- An explicit button as well as the swipe: the day panel is also the desktop right column, where
+               dragging a card with a mouse is undiscoverable. -->
+          <UButton
+            size="xs"
+            variant="ghost"
+            color="neutral"
+            icon="i-lucide-trash-2"
+            :title="t('pages.calendar.dayNotes.deleteTitle')"
+            @click.stop="() => { isDeleteOpen = true }"
+          />
+        </div>
+      </div>
+
+      <p v-if="note.content" class="text-sm text-gray-600 dark:text-gray-300 mt-1 whitespace-pre-line line-clamp-3">
+        {{ note.content }}
+      </p>
+
+      <div v-if="note.reminderTime" class="flex items-center gap-1.5 mt-1">
+        <UIcon name="i-lucide-bell" class="h-3.5 w-3.5 text-amber-600 dark:text-amber-400 shrink-0" />
+        <span class="text-xs text-gray-500 dark:text-gray-400">{{ note.reminderTime }}</span>
+      </div>
+
+      <div class="flex items-center gap-1.5 mt-0.5">
+        <span class="text-xs text-gray-500 dark:text-gray-400">{{ note.authorName }}</span>
+        <span class="text-xs text-gray-400">·</span>
+        <span class="text-xs text-gray-400 dark:text-gray-500">{{ createdTime }}</span>
+      </div>
+
+      <!-- Own line rather than appended to the author row: both names plus two times overflow a mobile card. -->
+      <div v-if="wasEdited" class="flex items-center gap-1.5 mt-0.5">
+        <UIcon name="i-lucide-pencil" class="h-3 w-3 text-gray-400 shrink-0" />
+        <span class="text-xs text-gray-400 dark:text-gray-500">
+          {{ t('pages.calendar.dayNotes.editedBy', { name: note.lastEditedByName }) }} · {{ editedTime }}
+        </span>
+      </div>
+    </div>
+
+    <!-- Delete confirmation -->
+    <AppDrawer
+      :open="isDeleteOpen"
+      :title="t('pages.calendar.dayNotes.deleteTitle')"
+      icon="i-lucide-trash-2"
+      fit="content"
+      @update:open="(v) => { isDeleteOpen = v }"
+    >
+      <p class="text-sm text-muted">{{ t('pages.calendar.dayNotes.deleteWarning') }}</p>
+      <div>
+        <span class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ t('pages.calendar.dayNotes.noteTitle') }}:</span>
+        <span class="text-sm ml-2">{{ note.title }}</span>
+      </div>
+      <template #footer>
+        <UButton :label="t('common.cancel')" color="neutral" variant="outline" @click="() => { isDeleteOpen = false }" />
+        <UButton :label="t('common.delete')" color="error" @click="confirmDelete" />
+      </template>
+    </AppDrawer>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { CalendarNoteResponse } from '~/types/calendarNote'
+
+const props = defineProps<{
+  note: CalendarNoteResponse
+}>()
+
+const emit = defineEmits<{
+  edit: [note: CalendarNoteResponse]
+  deleted: [publicId: string]
+}>()
+
+const { t, locale } = useI18n()
+
+const isDeleteOpen = ref(false)
+
+const cardEl = ref<HTMLElement | null>(null)
+const swipe = useSwipeActions(cardEl, {
+  onSwipeLeft: () => { isDeleteOpen.value = true },
+  onSwipeRight: () => emit('edit', props.note),
+  disabled: () => isDeleteOpen.value
+})
+
+const formatTime = (timestamp: string): string =>
+  new Date(timestamp).toLocaleTimeString(locale.value, { hour: '2-digit', minute: '2-digit' })
+
+const createdTime = computed(() => formatTime(props.note.createdAt))
+const editedTime = computed(() => props.note.lastEditedAt ? formatTime(props.note.lastEditedAt) : '')
+
+// lastEditedAt stays null until the note is actually edited, so this needs no timestamp comparison.
+const wasEdited = computed(() => !!props.note.lastEditedAt && !!props.note.lastEditedByName)
+
+function handleCardClick(event: MouseEvent) {
+  if (swipe.suppressClick.value) return
+  const target = event.target as HTMLElement
+  if (target.closest('a, button')) return
+  emit('edit', props.note)
+}
+
+function confirmDelete() {
+  isDeleteOpen.value = false
+  emit('deleted', props.note.publicId)
+}
+</script>

--- a/Homassy.Web/app/composables/api/index.ts
+++ b/Homassy.Web/app/composables/api/index.ts
@@ -1,5 +1,6 @@
 ﻿export * from './useAuthApi'
 export * from './useCalendarApi'
+export * from './useCalendarNoteApi'
 export * from './useAutomationApi'
 export * from './useErrorCodesApi'
 export * from './useFamilyApi'

--- a/Homassy.Web/app/composables/api/useCalendarNoteApi.ts
+++ b/Homassy.Web/app/composables/api/useCalendarNoteApi.ts
@@ -1,0 +1,39 @@
+import type {
+  CalendarNoteResponse,
+  CreateCalendarNoteRequest,
+  UpdateCalendarNoteRequest
+} from '~/types/calendarNote'
+
+export const useCalendarNoteApi = () => {
+  const client = useApiClient()
+
+  /**
+   * Notes for a date range. Error toasts are suppressed because this is one of several parallel week loads on
+   * the calendar page — a failure must not toast on every week navigation.
+   */
+  const getCalendarNotes = async (startDate: string, endDate: string) => {
+    return await client.get<CalendarNoteResponse[]>(
+      `/api/v1/CalendarNote?startDate=${startDate}&endDate=${endDate}`,
+      { showErrorToast: false }
+    )
+  }
+
+  const createCalendarNote = async (request: CreateCalendarNoteRequest) => {
+    return await client.post<CalendarNoteResponse>('/api/v1/CalendarNote', request)
+  }
+
+  const updateCalendarNote = async (publicId: string, request: UpdateCalendarNoteRequest) => {
+    return await client.put<CalendarNoteResponse>(`/api/v1/CalendarNote/${publicId}`, request)
+  }
+
+  const deleteCalendarNote = async (publicId: string) => {
+    return await client.delete(`/api/v1/CalendarNote/${publicId}`)
+  }
+
+  return {
+    getCalendarNotes,
+    createCalendarNote,
+    updateCalendarNote,
+    deleteCalendarNote
+  }
+}

--- a/Homassy.Web/app/pages/calendar.vue
+++ b/Homassy.Web/app/pages/calendar.vue
@@ -80,8 +80,15 @@
                 </div>
               </div>
 
-              <!-- Mobile: colored dots -->
-              <div class="flex flex-wrap gap-0.5 sm:hidden">
+              <!-- Mobile: colored dots. The note marker leads the row as an icon rather than a fifth dot
+                   colour — the date row above is already full at this width, and an icon reads as "a note". -->
+              <div class="flex flex-wrap items-center gap-0.5 sm:hidden">
+                <UIcon
+                  v-if="cell.notes.length > 0"
+                  name="i-lucide-sticky-note"
+                  class="h-2.5 w-2.5 text-emerald-500 shrink-0"
+                  :title="cell.notes.map(n => n.title).join(' · ')"
+                />
                 <span
                   v-for="(ev, ei) in cell.events"
                   :key="ei"
@@ -92,8 +99,22 @@
                 />
               </div>
 
-              <!-- Desktop: text chips -->
+              <!-- Desktop: text chips. Notes lead — on a wide screen the note's own text is the value. -->
               <div class="hidden sm:block space-y-0.5">
+                <div
+                  v-for="note in cell.notes.slice(0, 2)"
+                  :key="note.publicId"
+                  class="text-xs rounded px-1 py-0.5 truncate leading-tight bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
+                  :title="note.title"
+                >
+                  {{ note.title }}
+                </div>
+                <div
+                  v-if="cell.notes.length > 2"
+                  class="text-xs rounded px-1 py-0.5 truncate leading-tight bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
+                >
+                  {{ t('pages.calendar.dayNotes.moreNotes', { count: cell.notes.length - 2 }) }}
+                </div>
                 <div
                   v-for="(ev, ei) in cell.events"
                   :key="ei"
@@ -163,6 +184,12 @@
                     :detail="item.data.detail"
                     :color="item.data.color"
                   />
+                  <CalendarNoteCard
+                    v-else-if="item.kind === 'note'"
+                    :note="item.data"
+                    @edit="openEditNote"
+                    @deleted="onNoteDeleted"
+                  />
                   <CalendarActivityCard
                     v-else
                     :activity-type="item.data.activityType"
@@ -184,6 +211,16 @@
         </div>
       </div>
     </div>
+
+    <!-- Declared last: vaul stacks drawers by declaration order, not open order. -->
+    <CalendarNoteFormDrawer
+      :open="noteDrawerOpen"
+      :note="editingNote"
+      :date="selectedDay ?? todayStr"
+      @update:open="(v) => { noteDrawerOpen = v }"
+      @saved="onNoteSaved"
+      @conflict="onNoteConflict"
+    />
   </div>
 </template>
 
@@ -192,14 +229,19 @@ import { CalendarEventType } from '~/types/calendar'
 import type { CalendarEventInfo } from '~/types/calendar'
 import type { ExternalCalendarResponse } from '~/types/externalCalendar'
 import type { ActivityType, ActivityInfo } from '~/types/activity'
+import type { CalendarNoteResponse } from '~/types/calendarNote'
+import type { MasterDataDeletedEvent } from '~/types/masterData'
 import { useAuthStore } from '~/stores/auth'
 
 definePageMeta({ layout: 'auth' })
 
 const { t, locale } = useI18n()
+const toast = useToast()
 const { getCalendarEvents } = useCalendarApi()
 const { getActivities } = useUserApi()
 const { getExternalCalendars } = useExternalCalendarApi()
+const { getCalendarNotes, deleteCalendarNote } = useCalendarNoteApi()
+const masterDataSocket = useMasterDataSocket()
 const authStore = useAuthStore()
 const { markReady: markSplashReady } = useSplashScreen()
 
@@ -237,6 +279,7 @@ interface CalActivity {
 type DayItem =
   | { kind: 'event'; uid: string; data: CalEvent }
   | { kind: 'activity'; uid: string; data: CalActivity }
+  | { kind: 'note'; uid: string; data: CalendarNoteResponse }
 
 const toLocalDate = (date: Date): string => {
   const y = date.getFullYear()
@@ -250,6 +293,10 @@ const isLoading = ref(false)
 const calendarEvents = ref<CalEvent[]>([])
 const calendarActivities = ref<CalActivity[]>([])
 const externalCalendars = ref<ExternalCalendarResponse[]>([])
+const calendarNotes = ref<CalendarNoteResponse[]>([])
+
+const noteDrawerOpen = ref(false)
+const editingNote = ref<CalendarNoteResponse | null>(null)
 
 const selectedDay = ref<string | null>(toLocalDate(new Date()))
 const visibleCount = ref(5)
@@ -359,6 +406,22 @@ const activitiesByDate = computed(() => {
   return map
 })
 
+const notesByDate = computed(() => {
+  const map: Record<string, CalendarNoteResponse[]> = {}
+  for (const n of calendarNotes.value) {
+    ;(map[noteDayKey(n.date)] ??= []).push(n)
+  }
+  return map
+})
+
+// The visible week, in the `YYYY-MM-DD` form the buckets are keyed by. Extracted so the loader, the
+// currentDate watcher and the socket's range check all read the same source.
+const weekRange = computed(() => {
+  const end = new Date(weekStart.value)
+  end.setDate(end.getDate() + 6)
+  return { startKey: toLocalDate(weekStart.value), endKey: toLocalDate(end) }
+})
+
 const calendarCells = computed(() => {
   const cells = []
   const cur = new Date(weekStart.value)
@@ -370,7 +433,8 @@ const calendarCells = computed(() => {
       isToday: key === todayStr.value,
       dateStr: key,
       events: eventsByDate.value[key] ?? [],
-      activityCount: (activitiesByDate.value[key] ?? []).length
+      activityCount: (activitiesByDate.value[key] ?? []).length,
+      notes: notesByDate.value[key] ?? []
     })
     cur.setDate(cur.getDate() + 1)
   }
@@ -386,13 +450,20 @@ const selectedDayItems = computed((): DayItem[] => {
   const activities: DayItem[] = (activitiesByDate.value[selectedDay.value] ?? [])
     .map(a => ({ kind: 'activity' as const, uid: `activity-${a.publicId}`, data: a }))
 
-  const merged = [...events, ...activities].sort((a, b) => {
-    const aAllDay = a.kind === 'event' && a.data.isAllDay
-    const bAllDay = b.kind === 'event' && b.data.isAllDay
-    if (aAllDay !== bAllDay) return aAllDay ? -1 : 1
-    const ta = a.kind === 'event' ? a.data.startAt : a.data.timestamp
-    const tb = b.kind === 'event' ? b.data.startAt : b.data.timestamp
-    return tb.localeCompare(ta)
+  const notes: DayItem[] = (notesByDate.value[selectedDay.value] ?? [])
+    .map(n => ({ kind: 'note' as const, uid: `note-${n.publicId}`, data: n }))
+
+  // Notes pin above everything, all-day events next, timed items last — a faithful extension of the previous
+  // all-day-first comparator. A note has no time of day, and it is the only item on this page the user can act
+  // on, so burying it under a stack of iCal all-day entries would defeat the feature.
+  const rank = (i: DayItem) => i.kind === 'note' ? 0 : (i.kind === 'event' && i.data.isAllDay ? 1 : 2)
+  const stamp = (i: DayItem) =>
+    i.kind === 'event' ? i.data.startAt : i.kind === 'activity' ? i.data.timestamp : i.data.createdAt
+
+  const merged = [...events, ...activities, ...notes].sort((a, b) => {
+    const byRank = rank(a) - rank(b)
+    if (byRank !== 0) return byRank
+    return stamp(b).localeCompare(stamp(a))
   })
 
   // Events synthesised from an iCal feed all carry their *calendar's* PublicId,
@@ -481,23 +552,25 @@ const mapActivities = (items: ActivityInfo[]): CalActivity[] =>
 const loadEvents = async () => {
   isLoading.value = true
   try {
-    const weekEnd = new Date(weekStart.value)
-    weekEnd.setDate(weekEnd.getDate() + 6)
-    const startStr = toLocalDate(weekStart.value)
-    const endStr = toLocalDate(weekEnd)
+    const { startKey: startStr, endKey: endStr } = weekRange.value
 
-    const [eventsRes, activitiesRes, calendarsRes] = await Promise.all([
+    // allSettled, not all: with four sources a single failure would otherwise discard the other three and
+    // blank the whole week. Each source is applied independently.
+    const [eventsRes, activitiesRes, calendarsRes, notesRes] = await Promise.allSettled([
       getCalendarEvents(startStr, endStr),
       getActivities({ startDate: startStr, endDate: endStr, returnAll: true }),
-      getExternalCalendars()
+      getExternalCalendars(),
+      getCalendarNotes(startStr, endStr)
     ])
 
-    if (eventsRes.success && eventsRes.data)
-      calendarEvents.value = mapEvents(eventsRes.data)
-    if (activitiesRes.success && activitiesRes.data)
-      calendarActivities.value = mapActivities(activitiesRes.data.items)
-    if (calendarsRes.success && calendarsRes.data)
-      externalCalendars.value = calendarsRes.data.filter(c => c.isEnabled)
+    if (eventsRes.status === 'fulfilled' && eventsRes.value.success && eventsRes.value.data)
+      calendarEvents.value = mapEvents(eventsRes.value.data)
+    if (activitiesRes.status === 'fulfilled' && activitiesRes.value.success && activitiesRes.value.data)
+      calendarActivities.value = mapActivities(activitiesRes.value.data.items)
+    if (calendarsRes.status === 'fulfilled' && calendarsRes.value.success && calendarsRes.value.data)
+      externalCalendars.value = calendarsRes.value.data.filter(c => c.isEnabled)
+    if (notesRes.status === 'fulfilled' && notesRes.value.success && notesRes.value.data)
+      calendarNotes.value = notesRes.value.data
   } finally {
     isLoading.value = false
     // Normal PWA relaunch lands here — dismiss the boot splash once the
@@ -507,15 +580,118 @@ const loadEvents = async () => {
 }
 
 watch(currentDate, () => {
-  const weekEnd = new Date(weekStart.value)
-  weekEnd.setDate(weekEnd.getDate() + 6)
-  const startKey = toLocalDate(weekStart.value)
-  const endKey = toLocalDate(weekEnd)
+  const { startKey, endKey } = weekRange.value
   const todayInWeek = todayStr.value >= startKey && todayStr.value <= endKey
   selectedDay.value = todayInWeek ? todayStr.value : startKey
   loadEvents()
 })
-onMounted(loadEvents)
+
+// --- Day notes ------------------------------------------------------------------
+
+const openCreateNote = () => {
+  editingNote.value = null
+  noteDrawerOpen.value = true
+}
+
+const openEditNote = (note: CalendarNoteResponse) => {
+  editingNote.value = note
+  noteDrawerOpen.value = true
+}
+
+/**
+ * Idempotent and range-aware. Used by both the optimistic local patch and the socket handler, so the acting
+ * client's own echoed event is a no-op. A note whose date moved out of the loaded week is dropped rather than
+ * left behind, where it would linger in `calendarNotes` and silently miss every later bucket lookup.
+ */
+const upsertNote = (dto: CalendarNoteResponse) => {
+  const key = noteDayKey(dto.date)
+  const inRange = key >= weekRange.value.startKey && key <= weekRange.value.endKey
+  const idx = calendarNotes.value.findIndex(n => n.publicId === dto.publicId)
+
+  if (!inRange) {
+    if (idx >= 0) calendarNotes.value.splice(idx, 1)
+    return
+  }
+
+  if (idx >= 0) calendarNotes.value[idx] = dto
+  else calendarNotes.value.push(dto)
+}
+
+const removeNote = (publicId: string) => {
+  calendarNotes.value = calendarNotes.value.filter(n => n.publicId !== publicId)
+}
+
+const onNoteSaved = (dto: CalendarNoteResponse) => {
+  const wasEdit = !!editingNote.value
+  upsertNote(dto)
+  editingNote.value = null
+
+  toast.add({
+    title: wasEdit ? t('pages.calendar.dayNotes.updated') : t('pages.calendar.dayNotes.created'),
+    color: 'success',
+    icon: 'i-lucide-check-circle'
+  })
+
+  // Follow the note to its day, so a saved note never appears to vanish.
+  const key = noteDayKey(dto.date)
+  if (key === selectedDay.value) return
+
+  if (key >= weekRange.value.startKey && key <= weekRange.value.endKey) {
+    selectDay(key)
+    return
+  }
+
+  const [y, m, d] = key.split('-').map(Number)
+  if (y && m && d) currentDate.value = new Date(y, m - 1, d)
+}
+
+const onNoteDeleted = async (publicId: string) => {
+  const res = await deleteCalendarNote(publicId)
+  if (!res.success) return
+
+  removeNote(publicId)
+  toast.add({
+    title: t('pages.calendar.dayNotes.deleted'),
+    color: 'success',
+    icon: 'i-lucide-check-circle'
+  })
+}
+
+// A stale form lost the race; the week reload brings every open card back in sync.
+const onNoteConflict = () => {
+  editingNote.value = null
+  loadEvents()
+}
+
+const handleNoteUpserted = (dto: CalendarNoteResponse) => upsertNote(dto)
+const handleNoteDeleted = (payload: MasterDataDeletedEvent) => removeNote(payload.publicId)
+
+useFabActions(() => [{
+  label: t('pages.calendar.dayNotes.add'),
+  icon: 'i-lucide-notebook-pen',
+  handler: openCreateNote
+}])
+
+onMounted(async () => {
+  await loadEvents()
+
+  // Guarded: this page owns the boot splash and the FAB, so an offline socket must not stop it mounting.
+  try {
+    await masterDataSocket.ensureConnected()
+  } catch {
+    return
+  }
+
+  masterDataSocket.on('CalendarNoteUpserted', handleNoteUpserted)
+  masterDataSocket.on('CalendarNoteDeleted', handleNoteDeleted)
+  masterDataSocket.onReconnected(loadEvents)
+})
+
+onBeforeUnmount(() => {
+  masterDataSocket.off('CalendarNoteUpserted', handleNoteUpserted)
+  masterDataSocket.off('CalendarNoteDeleted', handleNoteDeleted)
+  masterDataSocket.offReconnected(loadEvents)
+})
 
 const prevWeek = () => {
   const d = new Date(currentDate.value)
@@ -564,6 +740,7 @@ const legendTypes = [
   { key: 'inventoryExpiration', dot: 'bg-red-500' },
   { key: 'automationExecution', dot: 'bg-blue-500' },
   { key: 'shoppingListDeadline', dot: 'bg-amber-500' },
-  { key: 'activity', dot: 'bg-gray-400' }
+  { key: 'activity', dot: 'bg-gray-400' },
+  { key: 'dayNote', dot: 'bg-emerald-500' }
 ]
 </script>

--- a/Homassy.Web/app/types/activity.ts
+++ b/Homassy.Web/app/types/activity.ts
@@ -49,7 +49,12 @@ export enum ActivityType {
   // Family Join Request Activities (27-29)
   FamilyJoinRequestCreate = 27,
   FamilyJoinRequestApprove = 28,
-  FamilyJoinRequestDecline = 29
+  FamilyJoinRequestDecline = 29,
+
+  // Calendar Note Activities (30-32)
+  CalendarNoteCreate = 30,
+  CalendarNoteUpdate = 31,
+  CalendarNoteDelete = 32
 }
 
 /**

--- a/Homassy.Web/app/types/calendarNote.ts
+++ b/Homassy.Web/app/types/calendarNote.ts
@@ -1,0 +1,40 @@
+export interface CalendarNoteResponse {
+  publicId: string
+  /** `YYYY-MM-DD` — the day the note is about. Never round-trip this through `Date`/`toISOString()`. */
+  date: string
+  title: string
+  content: string | null
+  /** Absolute instant the reminder fires, derived server-side. Read-only. */
+  reminderAt: string | null
+  /** `HH:mm` the author picked — what the edit form and the card should show. Null = no reminder. */
+  reminderTime: string | null
+  /** The `UserTimeZone` enum value `reminderTime` is anchored in. */
+  reminderTimeZone: number | null
+  reminderSentAt: string | null
+  authorPublicId: string
+  authorName: string
+  lastEditedByPublicId: string
+  lastEditedByName: string
+  createdAt: string
+  lastEditedAt: string | null
+  /** Opaque concurrency token; echo it back on update or the save is rejected with 409. */
+  version: string
+}
+
+export interface CreateCalendarNoteRequest {
+  date: string
+  title: string
+  content?: string | null
+  reminderTime?: string | null
+}
+
+export interface UpdateCalendarNoteRequest {
+  date?: string
+  title?: string
+  /** `''` erases the body; omitting the key leaves it unchanged. */
+  content?: string | null
+  /** Leaves the reminder unchanged when omitted — use `clearReminder` to remove it. */
+  reminderTime?: string | null
+  clearReminder?: boolean
+  version: string
+}

--- a/Homassy.Web/app/utils/calendarNotes.ts
+++ b/Homassy.Web/app/utils/calendarNotes.ts
@@ -1,0 +1,20 @@
+/** Default reminder time offered for a new note — mirrors "morning of the day". */
+export const DEFAULT_NOTE_REMINDER_TIME = '08:00'
+
+/** `HH:mm`, 24-hour. Used by the note form's Zod schema and matches what the API's parser accepts. */
+export const NOTE_REMINDER_TIME_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/
+
+/**
+ * Timezone-safe `YYYY-MM-DD` for a `CalendarDate`-style triple. Deliberately not via `Date`/`toISOString()`,
+ * which would shift the day for anyone east or west of UTC.
+ */
+export function toDateKey(year: number, month: number, day: number): string {
+  const mm = String(month).padStart(2, '0')
+  const dd = String(day).padStart(2, '0')
+  return `${year}-${mm}-${dd}`
+}
+
+/** The API may serialize the note date as a bare date or with a time part; the day key is all the UI needs. */
+export function noteDayKey(date: string): string {
+  return date.split('T')[0] ?? date
+}

--- a/Homassy.Web/i18n/locales/de.json
+++ b/Homassy.Web/i18n/locales/de.json
@@ -810,7 +810,32 @@
         "automationExecution": "Automatisierung",
         "shoppingListDeadline": "Einkaufsfrist",
         "activity": "Aktivität",
-        "externalCalendar": "Externer Kalender"
+        "externalCalendar": "Externer Kalender",
+        "dayNote": "Tagesnotiz"
+      },
+      "dayNotes": {
+        "add": "Notiz hinzufügen",
+        "create": "Neue Notiz",
+        "edit": "Notiz bearbeiten",
+        "date": "Tag",
+        "noteTitle": "Titel",
+        "titlePlaceholder": "Schule geschlossen",
+        "content": "Notiz",
+        "contentPlaceholder": "Was sollte die Familie über diesen Tag wissen?",
+        "titleRequired": "Ein Titel ist erforderlich",
+        "dateRequired": "Datum wählen",
+        "reminderEnabled": "Familie erinnern",
+        "reminderTime": "Erinnerungszeit",
+        "reminderHint": "Am Tag der Notiz wird zu dieser Zeit eine Push-Benachrichtigung in deiner Zeitzone gesendet.",
+        "invalidTime": "Gültige Zeit eingeben (HH:mm)",
+        "editedBy": "bearbeitet von {name}",
+        "moreNotes": "+{count} weitere",
+        "created": "Notiz hinzugefügt",
+        "updated": "Notiz aktualisiert",
+        "deleted": "Notiz gelöscht",
+        "saveFailed": "Notiz konnte nicht gespeichert werden",
+        "deleteTitle": "Notiz löschen",
+        "deleteWarning": "Die Notiz wird für alle Familienmitglieder entfernt. Das kann nicht rückgängig gemacht werden."
       },
       "views": {
         "month": "Monat",
@@ -882,7 +907,13 @@
     "SYSTEM-0001": "Ein unerwarteter Fehler ist aufgetreten.",
     "SYSTEM-0002": "Die Anfrage hat das Zeitlimit überschritten.",
     "SYSTEM-0003": "Die Anfrage wurde abgebrochen.",
-    "SYSTEM-0004": "Unbefugter Zugriff."
+    "SYSTEM-0004": "Unbefugter Zugriff.",
+    "CALNOTE-0001": "Die Notiz existiert nicht mehr.",
+    "CALNOTE-0002": "Du hast keinen Zugriff auf diese Notiz.",
+    "CALNOTE-0003": "Für Tagesnotizen musst du zu einer Familie gehören.",
+    "CALNOTE-0004": "Das Datum der Notiz fehlt oder ist ungültig.",
+    "CALNOTE-0005": "Die Erinnerungszeit ist ungültig.",
+    "CALNOTE-0006": "Jemand anderes hat diese Notiz geändert. Sie wurde neu geladen — bitte erneut versuchen."
   },
   "shoppingList": {
     "purchase": {
@@ -1464,7 +1495,10 @@
       "26": "Automatisierung ausgeführt",
       "27": "Beitrittsanfrage gesendet",
       "28": "Beitrittsanfrage genehmigt",
-      "29": "Beitrittsanfrage abgelehnt"
+      "29": "Beitrittsanfrage abgelehnt",
+      "30": "Notiz erstellt",
+      "31": "Notiz aktualisiert",
+      "32": "Notiz gelöscht"
     },
     "productCategory": {
       "0": "Sonstiges",

--- a/Homassy.Web/i18n/locales/en.json
+++ b/Homassy.Web/i18n/locales/en.json
@@ -812,7 +812,32 @@
         "automationExecution": "Automation",
         "shoppingListDeadline": "Shopping deadline",
         "activity": "Activity",
-        "externalCalendar": "External calendar"
+        "externalCalendar": "External calendar",
+        "dayNote": "Day note"
+      },
+      "dayNotes": {
+        "add": "Add note",
+        "create": "New note",
+        "edit": "Edit note",
+        "date": "Day",
+        "noteTitle": "Title",
+        "titlePlaceholder": "School closed",
+        "content": "Note",
+        "contentPlaceholder": "What should the family know about this day?",
+        "titleRequired": "A title is required",
+        "dateRequired": "Pick a date",
+        "reminderEnabled": "Remind the family",
+        "reminderTime": "Reminder time",
+        "reminderHint": "A push notification is sent at this time on the note's day, in your own timezone.",
+        "invalidTime": "Enter a valid time (HH:mm)",
+        "editedBy": "edited by {name}",
+        "moreNotes": "+{count} more",
+        "created": "Note added",
+        "updated": "Note updated",
+        "deleted": "Note deleted",
+        "saveFailed": "Failed to save the note",
+        "deleteTitle": "Delete note",
+        "deleteWarning": "This note will be removed for everyone in the family. This cannot be undone."
       },
       "views": {
         "month": "Month",
@@ -884,7 +909,13 @@
     "SYSTEM-0001": "An unexpected error occurred.",
     "SYSTEM-0002": "The request timed out.",
     "SYSTEM-0003": "The request was aborted.",
-    "SYSTEM-0004": "Unauthorized access."
+    "SYSTEM-0004": "Unauthorized access.",
+    "CALNOTE-0001": "The note no longer exists.",
+    "CALNOTE-0002": "You do not have access to this note.",
+    "CALNOTE-0003": "Join or create a family to use day notes.",
+    "CALNOTE-0004": "The note date is missing or invalid.",
+    "CALNOTE-0005": "The reminder time is invalid.",
+    "CALNOTE-0006": "Someone else changed this note. It has been reloaded — please try again."
   },
   "shoppingList": {
     "purchase": {
@@ -1464,7 +1495,10 @@
       "26": "Automation Executed",
       "27": "Join Request Sent",
       "28": "Join Request Approved",
-      "29": "Join Request Declined"
+      "29": "Join Request Declined",
+      "30": "Note Added",
+      "31": "Note Updated",
+      "32": "Note Deleted"
     },
     "productCategory": {
       "0": "Other",

--- a/Homassy.Web/i18n/locales/hu.json
+++ b/Homassy.Web/i18n/locales/hu.json
@@ -813,7 +813,32 @@
         "automationExecution": "Automatizálás",
         "shoppingListDeadline": "Bevásárlás határidő",
         "activity": "Tevékenység",
-        "externalCalendar": "Külső naptár"
+        "externalCalendar": "Külső naptár",
+        "dayNote": "Napi jegyzet"
+      },
+      "dayNotes": {
+        "add": "Jegyzet hozzáadása",
+        "create": "Új jegyzet",
+        "edit": "Jegyzet szerkesztése",
+        "date": "Nap",
+        "noteTitle": "Cím",
+        "titlePlaceholder": "Iskolai szünet",
+        "content": "Jegyzet",
+        "contentPlaceholder": "Mit érdemes tudni erről a napról?",
+        "titleRequired": "A cím megadása kötelező",
+        "dateRequired": "Válassz dátumot",
+        "reminderEnabled": "Emlékeztető a családnak",
+        "reminderTime": "Emlékeztető ideje",
+        "reminderHint": "A jegyzet napján, a saját időzónádban ebben az időpontban küldünk push értesítést.",
+        "invalidTime": "Érvényes időt adj meg (ÓÓ:PP)",
+        "editedBy": "szerkesztette: {name}",
+        "moreNotes": "+{count} további",
+        "created": "Jegyzet hozzáadva",
+        "updated": "Jegyzet frissítve",
+        "deleted": "Jegyzet törölve",
+        "saveFailed": "A jegyzet mentése nem sikerült",
+        "deleteTitle": "Jegyzet törlése",
+        "deleteWarning": "A jegyzet a család minden tagjánál törlődik. A művelet nem vonható vissza."
       },
       "views": {
         "month": "Hónap",
@@ -885,7 +910,13 @@
     "SYSTEM-0001": "Váratlan hiba történt.",
     "SYSTEM-0002": "A kérés túllépte az időkorlátot.",
     "SYSTEM-0003": "A kérést megszakították.",
-    "SYSTEM-0004": "Jogosulatlan hozzáférés."
+    "SYSTEM-0004": "Jogosulatlan hozzáférés.",
+    "CALNOTE-0001": "A jegyzet már nem létezik.",
+    "CALNOTE-0002": "Nincs hozzáférésed ehhez a jegyzethez.",
+    "CALNOTE-0003": "A napi jegyzetekhez családhoz kell tartoznod.",
+    "CALNOTE-0004": "A jegyzet dátuma hiányzik vagy érvénytelen.",
+    "CALNOTE-0005": "Az emlékeztető ideje érvénytelen.",
+    "CALNOTE-0006": "Valaki más módosította ezt a jegyzetet. Újratöltöttük — próbáld újra."
   },
   "shoppingList": {
     "purchase": {
@@ -1467,7 +1498,10 @@
       "26": "Automatizálás végrehajtva",
       "27": "Belépési kérelem elküldve",
       "28": "Belépési kérelem elfogadva",
-      "29": "Belépési kérelem elutasítva"
+      "29": "Belépési kérelem elutasítva",
+      "30": "Jegyzet létrehozva",
+      "31": "Jegyzet módosítva",
+      "32": "Jegyzet törölve"
     },
     "productCategory": {
       "0": "Egyéb",


### PR DESCRIPTION
Closes #60.

Family members can attach a free-text note to a calendar day, create/edit/delete it from the calendar view, and optionally have the family reminded about it.

## Where notes live

Notes are a **separate read source**, not a new `CalendarEventType`. That follows the precedent activities already set — own range endpoint, own `DayItem` kind, own card, own legend key — and avoids the alternative's two problems: `CalendarEventInfo` has no author/editor/reminder fields, so editing needs a full DTO anyway, which would mean fetching the same rows twice per week load and rendering every note twice in the day panel. `CalendarFunctions` and `CalendarEventType` are untouched.

`GET /api/v1/CalendarNote?startDate=&endDate=` plus `POST` / `PUT {publicId}` / `DELETE {publicId}`. A GET with query params rather than `CalendarController`'s POST-with-body, because `POST /` is needed here to create a note. The 93-day cap moved to `CalendarConstants.MaxDateRangeDays` so the two calendar endpoints cannot drift apart. A user with no family gets an empty list, not an error — their calendar still works.

`Date` is a `DateOnly` mapped to `date`. Every other `DateTime` in this codebase maps to `timestamptz`, which Npgsql reinterprets per session timezone: a note written for March 15 in Budapest could read as March 14 in New York, which defeats "visible to every family member".

## Reminders

The client sends a wall-clock `HH:mm`; the server combines it with the note's date **in the author's timezone** to derive one absolute `ReminderAt`, so every member is notified at the same instant. The intent — `ReminderTimeOfDay` plus a *snapshot* of `ReminderTimeZone` — is stored next to the instant, which is what lets a later date change be recomputed without guessing which zone to convert back through. The snapshot also means an editor in another zone, or the author later changing their profile timezone, cannot silently move an existing reminder.

Re-arm rules: a reminder is re-armed only when its instant actually moved **and** moved into the future. Without the future-only half, nudging the time back and forth across "now" would clear the sent marker repeatedly and re-push the same note. A title- or content-only edit leaves the marker alone. A reminder computed into the past beyond the catch-up window is retired at write time, so it does not sit in the pending index being re-examined every minute forever.

`CalendarNoteReminderService` polls every minute — a reminder is a wall-clock promise, and a 5-minute loop would turn "08:00" into "08:00–08:05". Each reminder is claimed with a single conditional `UPDATE ... WHERE ReminderSentAt IS NULL` committed **before** the push, so a crash, a restart inside the 15-minute catch-up window, or two replicas racing can only skip a send, never repeat one. The claim uses `ExecuteUpdateAsync`, which also avoids stamping `RecordChange.LastModifiedBy = -1` (that process has no `SessionInfoMiddleware`) and respects the soft-delete filter, so a deleted note can never fire. A 6-hourly sweep retires reminders that fell outside the window during an outage; there is no marker table to prune, since the dedup state lives on the note row.

**Push only.** The issue asks for push/in-app/email, but in-app does not exist here — `InAppNotificationsEnabled` is a bool no delivery code reads, with no entity, no endpoint, no UI, and no toggle bound in `NotificationsDrawer.vue`. Email exists for exactly two bespoke types and would need its own endpoint, template and content methods.

The issue also names `PushNotificationFunctions` for dispatch; that class is browser subscription CRUD and cannot send anything. The worker uses `FamilyPushNotifier` directly, as the other family notifiers do.

## Authorship and concurrent edits

Author and last editor are explicit FK columns (`Restrict`, no navigation properties) rather than `RecordChange.LastModifiedBy` — that is unjoinable JSON, holds only the last modifier, is overwritten by `DeleteRecord`, and uses `-1` as a sentinel. Display names resolve through `UserFunctions`' caches, so a whole range costs no extra queries.

Edits use optimistic concurrency, because the realtime channel means two members often have the same note open: the response carries an opaque `version`, the update must echo it, and a mismatch is **409 `CALNOTE-0006`**. A shadow `xmin` rowversion was the first attempt and does not work — Npgsql dropped its `UseXminAsConcurrencyToken` helper, and hand-declaring the system column makes the migration try to `CREATE` it. It is an explicit `RowVersion` GUID instead, deliberately *not* bumped by the reminder worker's claim so a fired reminder never invalidates an open form.

## SafeFreeText

`SanitizedStringAttribute` does not sanitize, it rejects: with the sanitizer resolved it refuses any value containing `<` or `>`, so a note reading `tartsd 5 °C < alatt` or `apply if x > 3` would have been a 400 with an opaque "potentially dangerous content" message. Fine on a 64-char label, wrong on 2000 characters of prose. The new attribute keeps the script-injection blocklist and drops the bracket rejection; `Title` keeps `SanitizedString`. Nothing safety-relevant is lost — the values render as text and reach notifications as plain text.

## Frontend

Emerald accent throughout. Day cells get a sticky-note icon on mobile (the date row is already full at ~42px) and note-title chips on desktop, capped at two. Notes sort to the top of the day panel — they have no time of day, and they are the only item on that page the user can act on. Cards offer tap-to-edit, a trash button (the panel is also the desktop right column, where dragging is undiscoverable) and swipe. Add is a FAB, which costs zero pixels in a layout whose cells are 38px tall.

`loadEvents` moves from `Promise.all` to `allSettled`: with a fourth source, one failure would otherwise discard the other three and blank the whole week. The page also gains its first socket wiring (`CalendarNoteUpserted` / `CalendarNoteDeleted`), with `ensureConnected` guarded so an offline socket cannot half-mount the page that owns the boot splash and the FAB.

## Verification

- `dotnet build` clean for API and Notifications. `Homassy.Tests` does not compile on `master` (96 errors in `ShoppingListActivityMonitorServiceTests` and `GracefulShutdownTests`, from an earlier rename) — this branch adds none, but it also means the suite could not be run.
- `eslint` clean on every changed file. `nuxi typecheck` at 160 errors, identical to the `master` baseline — the one error reported inside `calendar.vue` is the pre-existing `entries[0]` narrowing at `master:441`.
- Production `npm run build` succeeds.
- Reminder maths exercised against the shipped code (47 checks): summer/winter Budapest and Tokyo conversions, the DST spring-forward gap stepping to the first valid instant, fall-back ambiguity resolving deterministically, the full re-arm matrix, `StampIfAlreadyStale` boundaries, `DateOnly` JSON round-trip (`"2026-08-14"` in and out, no `Z`, no time part), and push copy in all three languages with truncation. `SafeFreeText` vs `SanitizedString` was checked with the real sanitizer wired into the validation context — without it the comparison proves nothing, since the attribute returns Success when the service is absent.

## Notes for review

- **A note and its activity legitimately land on different days.** Creating a note today for next Friday puts the activity on today's cell (`timestamp`) and the note on Friday's (`date`), so the gray badge and the emerald marker will often sit apart. Expected, not a defect.
- **The FAB is not gated on family membership.** The read returns `[]` for a family-less user so the page stays functional, but creating will 400 with `CALNOTE-0003`. Worth deciding whether to hide the action.
- **Migration conflict with #72.** Both branches add a migration and regenerate `HomassyDbContextModelSnapshot.cs`, so whichever merges second needs its migration regenerated. #72 also carries its own copy of the DST-safe `ToUtc`, which should collapse onto the `UserTimeZoneExtensions.LocalToUtc` helper added here once both have landed.
- Pre-existing and left alone: `$fetch` has no default timeout and `markSplashReady` has no upper bound, so a single stuck request can hold the PWA boot splash indefinitely. A fourth parallel call raises the odds but does not create the bug.
