### PR TITLE
feat(pwa): make the boot splash and iOS status bar follow the theme

### DIFF
--- a/Homassy.Web/CLAUDE.md
+++ b/Homassy.Web/CLAUDE.md
@@ -335,11 +335,54 @@ Language setting from the user's profile (`UserInfo.language`) is synced to the 
 ## PWA
 
 - **Auto-update** on new deployments
-- **Manifest**: standalone display, `#c9b8a0` theme color
+- **Manifest**: standalone display, `#c9b8a0` theme color, `#ffffff` background color
 - **Service Worker**: `workbox`-powered
   - Pages: `NetworkFirst`, 1-day cache
   - Static assets: `CacheFirst`, 30-day cache
   - Push notifications: `/sw-push.js` (imported into SW)
+
+---
+
+## Theming (light / dark / system)
+
+There is **no hand-written theme provider**. `@nuxt/ui` registers `@nuxtjs/color-mode` internally with `classSuffix: ''`, so the mode is a `light` / `dark` class on `<html>` — the same class Tailwind's `dark:` variant matches. The preference (`'light' | 'dark' | 'system'`, default `system`) is **device-local**: `localStorage`, key `nuxt-color-mode`. There is no server-side user preference, so the theme does not follow a user across devices.
+
+The UI is a segmented control in `app/pages/profile/index.vue` (`themeOptions`) that assigns straight to `colorMode.preference`. It must stay inside `<ClientOnly>` — the preference is unknown during SSR, so branching on it there is a hydration mismatch. `system` reacts live: color-mode listens to `prefers-color-scheme` changes.
+
+Colours always come from Nuxt UI's semantic tokens (`--ui-bg`, `--ui-text*`, `--ui-primary`, …), which flip themselves via the class. Only the `mocha` primary palette is project-owned (`app/assets/css/main.css`). **Never hardcode a hex where a token exists** — a literal cannot follow the theme.
+
+### The two places the theme has to be pushed out by hand
+
+1. **`<html>` background + `color-scheme`** (`app/assets/css/main.css`). Nuxt UI only styles `<body>`; iOS standalone samples the *root* background for the status-bar strip, so without this the top strip stays light in dark mode.
+2. **The `theme-color` meta** (`app/plugins/theme-color.client.ts`). Client-only, driven by a `watch` on `colorMode.value`, and it reads the value back from the root element's computed background so it can never drift from `--ui-bg`. It goes through `useHead` with `tagPriority: 'high'`: both the static tag in `nuxt.config.ts` and the manifest-derived one `@vite-pwa/nuxt` injects are unhead-managed, so a plain `meta.content = …` write gets reverted on the next flush. Reads are **synchronous, never `requestAnimationFrame`** — a backgrounded or non-compositing webview does not run animation frames.
+
+`apple-mobile-web-app-status-bar-style` stays `default`, and there is deliberately **no `viewport-fit=cover`** (so `env(safe-area-inset-*)` resolves to `0px` on iOS). Switching to `black-translucent` + `viewport-fit=cover` would give pixel control of the strip but hands the status-bar glyph colour to iOS and requires a safe-area audit of every top-fixed element.
+
+---
+
+## Boot splash
+
+`app/components/SplashScreen.vue` — a CSS overlay, **standalone-PWA only**, that covers the pre-hydration auth window. Not documented in the structure tree above; the moving parts:
+
+| File | Role |
+|---|---|
+| `app/components/SplashScreen.vue` | the overlay (logo + loading ring SSR'd, name/version `<ClientOnly>`) |
+| `app/composables/useSplashScreen.ts` | `markReady()` / `rearm()`, `MIN_VISIBLE_MS` floor |
+| `app/plugins/auth.ts` | owns the primary dismissal after the Kratos session resolves (6 s safety net) |
+| `app/pages/calendar.vue` | dismisses on a normal relaunch, after its first data load |
+| `app/plugins/splash-resume.client.ts` | re-shows it on a warm resume after ≥10 min backgrounded |
+| `nuxt.config.ts` | inline head script adding `.pwa-standalone` (iOS `navigator.standalone`) |
+
+It is theme-aware purely through tokens — `--ui-bg` matches the app background exactly, so the handoff is seamless in both themes, and no `:root.dark` selector is needed because color-mode sets the class from a blocking head script before first paint.
+
+**Easy to regress, all deliberate:**
+- `visibility: hidden` on `:root[data-splash-ready] .splash`, delayed `visibility 0s linear 0.55s` — iOS keeps sampling a `fixed; inset: 0` element's background for the status bar even at `opacity: 0` and translated off-screen.
+- Dual standalone gate: `@media (display-mode: standalone)` **and** `:root.pwa-standalone` (iOS does not reliably match the media query).
+- The `<style>` is unscoped on purpose, so `.splash` stays a literal class name for those selectors.
+- No `transform` on `.app-shell` — a transformed ancestor would become the containing block for the auth layout's `position: fixed` bottom nav.
+- Dismissal toggles an attribute on `<html>`, not a reactive `v-if`, so it works even before Vue mounts.
+
+The manifest's `background_color` takes a single value and cannot be theme-aware; it is tuned to the light background, so a dark-theme launch can show a brief light flash on Android's generated launch screen. There are no `apple-touch-startup-image` tags, so iOS shows a blank frame until the SSR HTML paints.
 
 ---
 

--- a/Homassy.Web/app/assets/css/main.css
+++ b/Homassy.Web/app/assets/css/main.css
@@ -17,6 +17,27 @@
   --color-mocha-950: #3F3027;
 }
 
+/* Nuxt UI only puts `bg-default` on <body>, leaving <html> transparent. iOS
+   standalone samples the root/page background for the status-bar strip (see
+   commit 18e821a, where the dismissed splash's background still tinted it), so a
+   transparent <html> is why the top strip stayed white after switching to the
+   dark theme. Painting the root with the same token fixes that — and the iOS
+   rubber-band overscroll colour with it. */
+html {
+  background-color: var(--ui-bg);
+}
+
+/* `color-scheme` also only lands on <body> (`scheme-light dark:scheme-dark`),
+   but browser-drawn surfaces — the canvas, scrollbars, the iOS status bar —
+   read it off the root element. */
+:root {
+  color-scheme: light;
+}
+
+:root.dark {
+  color-scheme: dark;
+}
+
 /* Persistent header height — measured at runtime by AppHeader.vue and published
    as this custom property. The default keeps layouts sane before/without a
    measurement (SSR, first paint) so pages can offset content with

--- a/Homassy.Web/app/components/SplashScreen.vue
+++ b/Homassy.Web/app/components/SplashScreen.vue
@@ -63,13 +63,21 @@ onMounted(async () => {
 <!-- Global (unscoped) so the `.splash` class stays literal for the
      `:root[data-splash-ready]` dismissal selector and the standalone media query. -->
 <style>
+/* Colours come from Nuxt UI's semantic tokens, never hardcoded hex: the splash
+   has to match whichever theme the app is in (light / dark / system). No
+   `:root.dark` selectors are needed — the `--ui-*` variables flip themselves via
+   the `light`/`dark` class, and @nuxtjs/color-mode puts that class on <html> from
+   a blocking inline head script, i.e. before the first paint. So the splash is
+   already the right theme on frame one, with no flash and no hydration diff. */
 .splash {
   display: none;
   position: fixed;
   inset: 0;
   z-index: 2147483000;
-  background-color: #2b2620;
-  color: #f5eee2;
+  /* Exactly the app's own background (`bg-default` on <body>), so the handoff
+     from splash to app is seamless in both themes. */
+  background-color: var(--ui-bg);
+  color: var(--ui-text-highlighted);
   transition:
     opacity 0.45s cubic-bezier(0.7, 0, 0.2, 1),
     transform 0.55s cubic-bezier(0.7, 0, 0.2, 1);
@@ -133,7 +141,7 @@ onMounted(async () => {
 }
 
 /* The loading ring is a rotating conic arc, masked into a thin band so the
-   espresso background shows through its centre; the static logo sits on top. */
+   page background shows through its centre; the static logo sits on top. */
 .splash__badge {
   position: relative;
   width: 128px;
@@ -147,7 +155,9 @@ onMounted(async () => {
   position: absolute;
   inset: 0;
   border-radius: 50%;
-  background: conic-gradient(from 0deg, #f0e6d6 0deg 250deg, #413a31 250deg 360deg);
+  /* Arc = the mocha primary, track = an accented surface — both readable on the
+     light and the dark background without a second rule. */
+  background: conic-gradient(from 0deg, var(--ui-primary) 0deg 250deg, var(--ui-bg-accented) 250deg 360deg);
   -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 7px), #000 calc(100% - 7px));
   mask: radial-gradient(farthest-side, transparent calc(100% - 7px), #000 calc(100% - 7px));
   animation: splash-spin 0.9s linear infinite;
@@ -167,7 +177,7 @@ onMounted(async () => {
 .splash__welcome-label {
   display: block;
   font-size: 0.8rem;
-  color: #a58e74;
+  color: var(--ui-text-muted);
 }
 
 .splash__name {

--- a/Homassy.Web/app/plugins/theme-color.client.ts
+++ b/Homassy.Web/app/plugins/theme-color.client.ts
@@ -1,0 +1,84 @@
+/**
+ * Keep the `theme-color` meta in sync with the active colour mode.
+ *
+ * Why it matters: on iOS standalone the status-bar strip follows the page/theme
+ * colour, and nothing used to rewrite the meta on a theme switch, so the top
+ * strip stayed light after switching to the dark theme.
+ *
+ * The value is *read back* from the root element's computed background
+ * (`html { background-color: var(--ui-bg) }`, see assets/css/main.css) rather
+ * than being a second copy of the palette — so it can never drift from the app's
+ * own background, whatever `--ui-bg` resolves to.
+ *
+ * It goes through `useHead` (not a direct DOM write): both nuxt.config's static
+ * tag and @vite-pwa/nuxt's manifest-derived one are unhead-managed, so a manual
+ * `meta.content = …` gets reverted on unhead's next flush. `tagPriority: 'high'`
+ * makes this entry win the `meta[name]` dedupe.
+ *
+ * Client-only: reading computed styles needs a DOM, and the colour mode is
+ * `unknown` during SSR — branching on it there would be a hydration mismatch.
+ */
+
+// Normalise to `#rrggbb`. Tailwind v4 palettes are oklch, and that is what
+// getComputedStyle hands back; a hex triplet is what every `theme-color`
+// implementation is guaranteed to parse. Canvas does the conversion, using the
+// same colour parser as CSS, so it round-trips whatever the engine understood.
+function toHex(color: string): string {
+  const canvas = document.createElement('canvas')
+  canvas.width = canvas.height = 1
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return color
+  ctx.fillStyle = color
+  ctx.fillRect(0, 0, 1, 1)
+  const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data
+  if (r === undefined || g === undefined || b === undefined) return color
+  return `#${[r, g, b].map(c => c.toString(16).padStart(2, '0')).join('')}`
+}
+
+export default defineNuxtPlugin((nuxtApp) => {
+  const colorMode = useColorMode()
+  // Passed to useHead as a ref (not a getter) — that is what unhead tracks, so
+  // every write here re-patches the tag.
+  const themeColor = ref<string | undefined>()
+
+  const read = () => {
+    const bg = getComputedStyle(document.documentElement).backgroundColor
+    // Transparent means the stylesheet has not applied yet — leave the SSR value
+    // in place rather than committing black.
+    if (!bg || bg === 'transparent' || bg.startsWith('rgba(0, 0, 0, 0')) return
+    themeColor.value = toHex(bg)
+  }
+
+  useHead({
+    meta: [
+      {
+        name: 'theme-color',
+        content: themeColor,
+        tagPriority: 'high'
+      }
+    ]
+  })
+
+  // The `light`/`dark` class is already on <html> at this point (color-mode sets
+  // it from a blocking head script), so read straight away…
+  read()
+  // …and again once mounted, because in dev the stylesheet is injected by Vite and
+  // may not have applied yet, in which case the first read bails on transparent.
+  nuxtApp.hook('app:mounted', read)
+
+  // Synchronous on purpose. This watcher is registered after color-mode's own
+  // (module plugins run before app plugins), so by the time it fires the class
+  // swap is already committed and getComputedStyle resolves the new theme.
+  // Deliberately not deferred to requestAnimationFrame: a backgrounded or
+  // non-compositing webview does not run animation frames.
+  watch(() => colorMode.value, read)
+
+  // A suspended standalone webview can miss an OS-level light/dark switch while
+  // backgrounded, so re-read on resume. Only for 'system' — an explicit
+  // preference cannot go stale. Mirrors plugins/splash-resume.client.ts.
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible' && colorMode.preference === 'system') {
+      read()
+    }
+  })
+})

--- a/Homassy.Web/nuxt.config.ts
+++ b/Homassy.Web/nuxt.config.ts
@@ -10,7 +10,13 @@ export default defineNuxtConfig({
     pageTransition: { name: 'page', mode: 'out-in' },
     head: {
       meta: [
-        { name: 'theme-color', content: '#c9b8a0' },
+        // Light-theme value only — SSR cannot know the preference (it lives in
+        // localStorage), so this matches @nuxtjs/color-mode's `fallback: 'light'`.
+        // plugins/theme-color.client.ts takes it over on the client and keeps it
+        // equal to the app's own background in whichever theme is active.
+        // `tagPriority: 'high'` so it wins the `meta[name]` dedupe against the
+        // manifest-derived tag @vite-pwa/nuxt injects (brand tan, theme-blind).
+        { name: 'theme-color', content: '#ffffff', tagPriority: 'high' },
         { name: 'mobile-web-app-capable', content: 'yes' },
         { name: 'apple-mobile-web-app-capable', content: 'yes' },
         { name: 'apple-mobile-web-app-status-bar-style', content: 'default' }
@@ -74,9 +80,11 @@ export default defineNuxtConfig({
       name: 'Homassy',
       short_name: 'Homassy',
       theme_color: '#c9b8a0',
-      // Matches the in-app splash background so the OS-generated launch screen
-      // hands off seamlessly into it (SplashScreen.vue uses the same espresso).
-      background_color: '#2b2620',
+      // The manifest takes a single value and cannot be theme-aware, while the
+      // in-app splash now follows the active theme (SplashScreen.vue uses
+      // `--ui-bg`). Tuned to the light background, so a dark-theme launch can
+      // show a brief light flash on Android's generated launch screen.
+      background_color: '#ffffff',
       display: 'standalone',
       start_url: '/',
       icons: [


### PR DESCRIPTION
## Problem

The boot splash had a hardcoded espresso palette (`#2b2620` background, cream text, warm ring), while the app itself supports light / dark / system via `@nuxtjs/color-mode`. A light-theme user therefore got a dark splash handing off into a light app.

Separately, in an installed iOS PWA the status-bar strip stayed light after switching to the dark theme.

## Root causes

**Splash:** literal hex values cannot follow a theme.

**iOS status bar — two independent causes, both fixed here:**

1. `<html>` had no `background-color`. Nuxt UI only styles `<body>` (`bg-default`), but iOS samples the **root** background for the strip. Commit 18e821a already proved this empirically from the other direction: the dismissed splash's espresso kept tinting the strip until it was given `visibility: hidden`.
2. The `theme-color` meta was a static tan value (`#c9b8a0`) that nothing ever rewrote on a theme switch.

## Changes

**`app/components/SplashScreen.vue`** — every hardcoded colour replaced with a Nuxt UI semantic token. No `:root.dark` selector is needed: the `--ui-*` variables flip themselves via the `light`/`dark` class, which colour-mode sets from a blocking head script before first paint, so the splash is already correct on frame one.

| | light | dark |
|---|---|---|
| background `var(--ui-bg)` | `#ffffff` | `#0f172b` — exactly the app background |
| text `var(--ui-text-highlighted)` | slate-900 | white |
| ring arc `var(--ui-primary)` | `#B8956A` | `#C9B8A0` |
| ring track `var(--ui-bg-accented)` | slate-200 | slate-700 |

**`app/assets/css/main.css`** — `html { background-color: var(--ui-bg) }`, plus `color-scheme` on `:root` (it was only on `<body>`, but browser-drawn surfaces read it off the root). Also fixes the iOS rubber-band overscroll colour.

**`app/plugins/theme-color.client.ts`** (new) — watches `colorMode.value` and keeps the `theme-color` meta in sync. Two implementation details that are load-bearing:

- It goes through `useHead` with `tagPriority: 'high'`, not a direct DOM write. Both the static tag in `nuxt.config.ts` and the manifest-derived one `@vite-pwa/nuxt` injects are unhead-managed, so a plain `meta.content = …` gets reverted on the next flush.
- Reads are **synchronous**, not deferred to `requestAnimationFrame` — a backgrounded or non-compositing webview does not run animation frames. Our watcher is registered after colour-mode's own (module plugins run before app plugins), so the class swap is already committed when it fires.

The value is read back from the root element's computed background rather than duplicating the palette, so it cannot drift from `--ui-bg`. A canvas round-trip normalises it to `#rrggbb`, since Tailwind v4 palettes are `oklch`.

**`nuxt.config.ts`** — `theme-color` default is now the light background (matching colour-mode's `fallback: 'light'`) with `tagPriority: 'high'`; `manifest.background_color` moved from espresso to `#ffffff`. The manifest takes a single value and cannot be theme-aware, so a dark-theme launch can show a brief light flash on Android's generated launch screen.

**`CLAUDE.md`** — the splash and the theme system were entirely undocumented. Added sections covering both, including the pieces that are easy to regress.

## `system` preference

Already worked — colour-mode listens to `prefers-color-scheme` changes. The only real addition is the plugin's `visibilitychange` branch, which re-reads on resume: a suspended standalone webview can miss an OS-level light/dark switch while backgrounded.

## Notes / deliberately out of scope

- `apple-mobile-web-app-status-bar-style` stays `default`, and there is still no `viewport-fit=cover`. Switching to `black-translucent` would give pixel control of the strip but hands the status-bar glyph colour to iOS and needs a safe-area audit of every top-fixed element. That is the fallback if a given iOS version still does not follow.
- There are no `apple-touch-startup-image` tags, so iOS still shows a light blank frame before the SSR HTML paints. Media-scoping those by `prefers-color-scheme` would need per-device-size images — separate task.
- The theme remains device-local (`localStorage`, key `nuxt-color-mode`); there is no server-side user preference, so it does not follow a user across devices.
- The 18e821a `visibility: hidden` dismissal fix is verified intact.
